### PR TITLE
Marquee block

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -1,4 +1,4 @@
-main > .section-outer > .section.hero-container{
+main > .section-outer > .section.hero-container {
   max-width: 100%;
   padding: 0;
   margin: 0;

--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -59,9 +59,9 @@ main > .section-outer > .section.marquee-container {
     font-family: var(--ff-acceptance-extra-bold);
 }
 
-@media screen and (width >= 576px) {
+/* @media screen and (width >= 576px) {
     .marquee {}
-}
+} */
 
 @media screen and (width >= 768px) {
     .marquee .foreground > div {
@@ -69,7 +69,7 @@ main > .section-outer > .section.marquee-container {
     }
 }
 
-@media screen and (width >= 992px) {
+/* @media screen and (width >= 992px) {
     .marquee {}
 }
 
@@ -79,4 +79,4 @@ main > .section-outer > .section.marquee-container {
 
 @media screen and (width >= 1400px) {
     .marquee {}
-}
+} */

--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -21,15 +21,36 @@ main > .section-outer > .section.marquee-container {
 
 .marquee {
     position: relative;
-    min-height: 400px;
     color: var(--background-color);
-    padding: 1.5rem;
     display: flex;
-    align-items: center;
+    flex-direction: column;
 }
 
+/* background */
+.marquee .background {
+    height: 470px;
+}
+
+.marquee .background > div,
+.marquee .background > div p { 
+    margin: 0;
+    height: 100%; 
+}
+
+.marquee .background img,
+.marquee .background video {
+    object-fit: cover;
+    width: 100%;
+    height: 100%;
+}
+
+/* foreground */
 .marquee .foreground {
     flex-grow: 1;
+    inset: 0;
+    position: absolute;
+    z-index: 0;
+    padding: 1em;
 }
 
 .marquee p.intro {
@@ -59,13 +80,44 @@ main > .section-outer > .section.marquee-container {
     font-family: var(--ff-acceptance-extra-bold);
 }
 
+.marquee.max-width-50 .foreground > div {
+    max-width: 50%;
+}
+
+.marquee.max-width-75 .foreground > div {
+    max-width: 75%;
+}
+
+.marquee.max-width-100 .foreground > div {
+    max-width: 100%;
+}
+
 /* @media screen and (width >= 576px) {
+    .marquee {}
+}
+
+@media screen and (width >= 768px) {
     .marquee {}
 } */
 
-@media screen and (width >= 768px) {
+/* TODO: This MQ is unconventional */
+@media screen and (min-width: 960px) {
+
+    .marquee .foreground {
+        display: flex;
+        align-items: center;
+    }
+
     .marquee .foreground > div {
-        width: 50%;
+        max-width: 50%;
+    }
+    
+    .marquee.max-width-75-desktop .foreground > div {
+        max-width: 75%;
+    }
+    
+    .marquee.max-width-100-desktop .foreground > div {
+        max-width: 100%;
     }
 }
 

--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -1,0 +1,82 @@
+main > .section-outer > .section.marquee-container {
+    max-width: 100%;
+    padding: 0;
+    margin: 0;
+}
+
+.marquee-container .marquee-wrapper {
+    max-width: unset;
+    padding: 0;
+}
+
+.marquee, 
+.marquee p {
+    color: white;
+}
+
+.marquee.dark-text, 
+.marquee.dark-text p {
+    color: black;
+}
+
+.marquee {
+    position: relative;
+    min-height: 400px;
+    color: var(--background-color);
+    padding: 1.5rem;
+    display: flex;
+    align-items: center;
+}
+
+.marquee .foreground {
+    flex-grow: 1;
+}
+
+.marquee p.intro {
+    color: var(--bs-black);
+    margin-bottom: 1rem;
+}
+
+.marquee p.intro span {
+    background-color: var(--very-light-gray);
+    padding: .5rem .5rem .25rem;
+    font-family: var(--ff-acceptance-demi-bold);
+}
+
+.marquee p.intro div {
+    height: 2px;
+    background: var(--very-light-gray);
+}
+
+.marquee .action-area {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.marquee .supplemental-text {
+    font-family: var(--ff-acceptance-extra-bold);
+}
+
+@media screen and (width >= 576px) {
+    .marquee {}
+}
+
+@media screen and (width >= 768px) {
+    .marquee .foreground > div {
+        width: 50%;
+    }
+}
+
+@media screen and (width >= 992px) {
+    .marquee {}
+}
+
+@media screen and (width >= 1200px) {
+    .marquee {}
+}
+
+@media screen and (width >= 1400px) {
+    .marquee {}
+}

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -26,7 +26,6 @@ export default function decorate(block) {
   const children = block.querySelectorAll(':scope > div');
   const foreground = children[children.length - 1];
   if (children.length > 1) {
-    children[0].classList.add('background');
     decorateBlockBg(block, children[0], { useHandleFocalpoint: true });
   }
   foreground.classList.add('foreground', 'container');

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -1,0 +1,44 @@
+import { createTag } from '../../libs/utils/utils.js';
+import { decorateBlockBg, decorateButtons } from '../../libs/utils/decorate.js';
+
+function decorateIntro(el) {
+  const heading = el.querySelector('h1, h2, h3, h4, h5, h6');
+  if (!heading) return;
+  const intro = heading.previousElementSibling;
+  if (!intro) return;
+  intro.classList.add('intro');
+  const [text, colorsArray] = intro.textContent.trim().split('{');
+  intro.innerHTML = '';
+  const label = createTag('span', null, text.trim());
+  const border = createTag('div');
+  intro.appendChild(label);
+  intro.appendChild(border);
+  if (colorsArray) {
+    const colors = colorsArray.replace('}', '').split(',');
+    const [bgColor, txtColor] = colors;
+    label.style.color = txtColor || '#ffffff';
+    label.style.backgroundColor = bgColor;
+    border.style.backgroundColor = bgColor;
+  }
+}
+
+export default function decorate(block) {
+  const children = block.querySelectorAll(':scope > div');
+  const foreground = children[children.length - 1];
+  if (children.length > 1) {
+    children[0].classList.add('background');
+    decorateBlockBg(block, children[0], { useHandleFocalpoint: true });
+  }
+  foreground.classList.add('foreground', 'container');
+  decorateIntro(foreground);
+  decorateButtons(foreground);
+  const buttons = foreground.querySelectorAll('.button');
+  buttons.forEach((button) => {
+    const actionArea = button.closest('p, div');
+    if (!actionArea) return;
+    actionArea.classList.add('action-area');
+  });
+  const lastAction = buttons[buttons.length - 1]?.closest('p, div');
+  if (!lastAction) return;
+  lastAction.nextElementSibling?.classList.add('supplemental-text');
+}

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -7,7 +7,7 @@ export function decorateButtons(el) {
   buttons.forEach((button) => {
     let target = button;
     const parent = button.parentElement;
-    const buttonType = buttonTypeMap[parent.nodeName] || 'outline';
+    const buttonType = buttonTypeMap[parent.nodeName] || 'primary';
     if (button.nodeName === 'STRONG') {
       target = parent;
     } else {
@@ -15,13 +15,10 @@ export function decorateButtons(el) {
       parent.remove();
     }
     target.classList.add('button', buttonType);
-    const customClasses = target.href && [...target.href.matchAll(/#_button-([a-zA-Z-]+)/g)];
+    const customClasses = target.textContent && [...target.textContent.matchAll(/#_button-([a-zA-Z-]+)/g)];
     if (customClasses) {
       customClasses.forEach((match) => {
-        target.href = target.href.replace(match[0], '');
-        if (target.dataset.modalHash) {
-          target.setAttribute('data-modal-hash', target.dataset.modalHash.replace(match[0], ''));
-        }
+        target.textContent = target.textContent.replace(match[0], '');
         target.classList.add(match[1]);
       });
     }

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -1,0 +1,69 @@
+// Shared block decorate functions
+
+export function decorateButtons(el) {
+  const buttons = el.querySelectorAll('em a, strong a, p > a strong');
+  if (buttons.length === 0) return;
+  const buttonTypeMap = { STRONG: 'primary', EM: 'secondary', A: 'link' };
+  buttons.forEach((button) => {
+    let target = button;
+    const parent = button.parentElement;
+    const buttonType = buttonTypeMap[parent.nodeName] || 'outline';
+    if (button.nodeName === 'STRONG') {
+      target = parent;
+    } else {
+      parent.insertAdjacentElement('afterend', button);
+      parent.remove();
+    }
+    target.classList.add('button', buttonType);
+    const customClasses = target.href && [...target.href.matchAll(/#_button-([a-zA-Z-]+)/g)];
+    if (customClasses) {
+      customClasses.forEach((match) => {
+        target.href = target.href.replace(match[0], '');
+        if (target.dataset.modalHash) {
+          target.setAttribute('data-modal-hash', target.dataset.modalHash.replace(match[0], ''));
+        }
+        target.classList.add(match[1]);
+      });
+    }
+  });
+}
+
+export function handleFocalpoint(pic, child, removeChild) {
+  const image = pic.querySelector('img');
+  if (!child || !image) return;
+  let text = '';
+  if (child.childElementCount === 2) {
+    const dataElement = child.querySelectorAll('p')[1];
+    text = dataElement?.textContent;
+    if (removeChild) dataElement?.remove();
+  } else if (child.textContent) {
+    text = child.textContent;
+    const childData = child.childNodes;
+    if (removeChild) childData.forEach((c) => c.nodeType === Node.TEXT_NODE && c.remove());
+  }
+  if (!text) return;
+  const directions = text.trim().toLowerCase().split(',');
+  const [x, y = ''] = directions;
+  image.style.objectPosition = `${x} ${y}`;
+}
+
+export async function decorateBlockBg(block, node, { useHandleFocalpoint = false, className = 'background' } = {}) {
+  const childCount = node.childElementCount;
+  if (node.querySelector('img, video') || childCount > 1) {
+    node.classList.add(className);
+    const twoVP = [['mobile-only'], ['tablet-only', 'desktop-only']];
+    const threeVP = [['mobile-only'], ['tablet-only'], ['desktop-only']];
+    const viewports = childCount === 2 ? twoVP : threeVP;
+    [...node.children].forEach((child, i) => {
+      if (childCount > 1) child.classList.add(...viewports[i]);
+      const pic = child.querySelector('picture');
+      if (useHandleFocalpoint && pic
+        && (child.childElementCount === 2 || child.textContent?.trim())) {
+        handleFocalpoint(pic, child, true);
+      }
+    });
+  } else {
+    block.style.background = node.textContent;
+    node.remove();
+  }
+}

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1,0 +1,27 @@
+// Common Utils
+
+export function isInTextNode(node) {
+  return node.parentElement.firstChild.nodeType === Node.TEXT_NODE;
+}
+
+export function createTag(tag, attributes, html, options = {}) {
+  const el = document.createElement(tag);
+  if (html) {
+    if (html instanceof HTMLElement
+      || html instanceof SVGElement
+      || html instanceof DocumentFragment) {
+      el.append(html);
+    } else if (Array.isArray(html)) {
+      el.append(...html);
+    } else {
+      el.insertAdjacentHTML('beforeend', html);
+    }
+  }
+  if (attributes) {
+    Object.entries(attributes).forEach(([key, val]) => {
+      el.setAttribute(key, val);
+    });
+  }
+  options.parent?.append(el);
+  return el;
+}

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -391,7 +391,11 @@ function wrapTextNodes(block) {
  * @param {Element} element container element
  */
 function decorateButtons(element) {
+  const selfDecoratingBlocks = ['marquee'];
   element.querySelectorAll('a').forEach((a) => {
+    // check if a is in a block that decorates itself
+    const isInBlock = selfDecoratingBlocks.some((block) => a.closest(`.${block}`));
+    if (isInBlock) return;
     a.title = a.title || a.textContent;
     if (a.href !== a.textContent) {
       const up = a.parentElement;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -334,50 +334,18 @@ main > .section-outer > .section.width-75 > div {
 }
 
 @media screen and (width >= 576px) {
-  main > .section-outer > .section,
-  .block .container {
-    max-width: 540px;
-  }
+    main > .section-outer > .section,
+    .block .container {
+        max-width: 540px;
+    }
 }
 
 @media screen and (width >= 768px) {
-   main > .section-outer > .section,
-   .block .container {
-    max-width: 720px;
-  }
-}
+    main > .section-outer > .section,
+    .block .container {
+        max-width: 720px;
+    }
 
-@media screen and (width >= 992px) {
-   main > .section-outer > .section,
-   .block .container {
-    max-width: 960px;
-  }
-}
-
-@media screen and (width >= 1200px) {
-   main > .section-outer > .section,
-   .block .container {
-    max-width: 1140px;
-  }
-}
-
-@media screen and (width >= 1400px) {
-   main > .section-outer > .section,
-   .block .container {
-    max-width: 1320px;
-  }
-}
-
-/* section metadata */
-main .section.light,
-main .section.highlight {
-  background-color: var(--light-color);
-  margin: 0;
-  padding: 40px 0;
-}
-
-/* Tablet up */
-@media screen and (width >= 768px) {
     .block .background .mobile-only,
     .block .background .desktop-only {
         display: none;
@@ -388,14 +356,40 @@ main .section.highlight {
     }
 }
 
-/* desktop up */
+@media screen and (width >= 992px) {
+    main > .section-outer > .section,
+    .block .container {
+        max-width: 960px;
+    }
+}
+
 @media screen and (width >= 1200px) {
+    main > .section-outer > .section,
+    .block .container {
+        max-width: 1140px;
+    }
+
     .block .background .mobile-only,
     .block .background .tablet-only {
-      display: none;
+        display: none;
     }
-  
+
     .block .background .desktop-only {
-      display: block;
+        display: block;
     }
+}
+
+@media screen and (width >= 1400px) {
+    main > .section-outer > .section,
+    .block .container {
+        max-width: 1320px;
+    }
+}
+
+/* section metadata */
+main .section.light,
+main .section.highlight {
+    background-color: var(--light-color);
+    margin: 0;
+    padding: 40px 0;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -54,7 +54,6 @@
   --secondary-btn-border: #2b4361;
   --secondary-btn-border-hover: #0A293B;
   --very-light-gray: #fcfcfc;
-
   --buton-bg-blue: #c4eefa;
 
   /* fonts */
@@ -291,10 +290,7 @@ main img {
 .block .background {
     overflow: hidden;
     position: absolute;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
+    inset: 0;
     z-index: -1;
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -55,6 +55,8 @@
   --secondary-btn-border-hover: #0A293B;
   --very-light-gray: #fcfcfc;
 
+  --buton-bg-blue: #c4eefa;
+
   /* fonts */
   --body-font-family: 'Visibly Regular', visby-regular-fallback, sans-serif;
   --heading-font-family: 'Acceptance Bold', acceptance-bold-fallback, sans-serif;
@@ -221,6 +223,7 @@ button {
   text-transform: uppercase;
   font-family: var(--heading-font-family);
   text-decoration: none;
+  white-space: nowrap;
 }
 
 a.button.primary {
@@ -229,6 +232,7 @@ a.button.primary {
   border: 1px solid rgba(255 255 255 0%);
   padding: .5rem 1.5rem;
   border-radius: .375rem;
+  transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out
 }
 
 a.button:hover,
@@ -262,6 +266,10 @@ button.secondary:hover {
   color: var(--secondary-btn-border-hover);
 }
 
+a.button.primary.blue{
+    background-color: var(--buton-bg-blue);
+}
+
 main img {
   max-width: 100%;
   width: auto;
@@ -279,8 +287,40 @@ main img {
   width: 100%;
 }
 
+/* blocks */
+.block .background {
+    overflow: hidden;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    z-index: -1;
+}
+
+.block .background > div p { 
+    margin: 0;
+    height: 100%; 
+}
+
+.block .background > div { height: 100%; }
+
+.block .background img,
+.block .background video {
+    object-fit: cover;
+    width: 100%;
+    height: 100%;
+    object-position: center top;
+}
+
+.block .background .tablet-only,
+.block .background .desktop-only {
+    display: none;
+}
+
 /* sections */
-main > .section-outer > .section {
+main > .section-outer > .section,
+.block .container {
   max-width: 100%;
   margin: 40px auto;
 }
@@ -298,31 +338,36 @@ main > .section-outer > .section.width-75 > div {
 }
 
 @media screen and (width >= 576px) {
-  main > .section-outer > .section {
+  main > .section-outer > .section,
+  .block .container {
     max-width: 540px;
   }
 }
 
 @media screen and (width >= 768px) {
-   main > .section-outer > .section {
+   main > .section-outer > .section,
+   .block .container {
     max-width: 720px;
   }
 }
 
 @media screen and (width >= 992px) {
-   main > .section-outer > .section {
+   main > .section-outer > .section,
+   .block .container {
     max-width: 960px;
   }
 }
 
 @media screen and (width >= 1200px) {
-   main > .section-outer > .section {
+   main > .section-outer > .section,
+   .block .container {
     max-width: 1140px;
   }
 }
 
 @media screen and (width >= 1400px) {
-   main > .section-outer > .section {
+   main > .section-outer > .section,
+   .block .container {
     max-width: 1320px;
   }
 }
@@ -333,4 +378,28 @@ main .section.highlight {
   background-color: var(--light-color);
   margin: 0;
   padding: 40px 0;
+}
+
+/* Tablet up */
+@media screen and (width >= 768px) {
+    .block .background .mobile-only,
+    .block .background .desktop-only {
+        display: none;
+    }
+
+    .block .background .tablet-only {
+        display: block;
+    }
+}
+
+/* desktop up */
+@media screen and (width >= 1200px) {
+    .block .background .mobile-only,
+    .block .background .tablet-only {
+      display: none;
+    }
+  
+    .block .background .desktop-only {
+      display: block;
+    }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -265,7 +265,7 @@ button.secondary:hover {
   color: var(--secondary-btn-border-hover);
 }
 
-a.button.primary.blue{
+a.button.primary.blue {
     background-color: var(--buton-bg-blue);
 }
 
@@ -286,31 +286,8 @@ main img {
   width: 100%;
 }
 
-/* blocks */
-.block .background {
-    overflow: hidden;
-    position: absolute;
-    inset: 0;
-    z-index: -1;
-}
-
-.block .background > div p { 
-    margin: 0;
-    height: 100%; 
-}
-
-.block .background > div { height: 100%; }
-
-.block .background img,
-.block .background video {
-    object-fit: cover;
-    width: 100%;
-    height: 100%;
-    object-position: center top;
-}
-
-.block .background .tablet-only,
-.block .background .desktop-only {
+.marquee .background .tablet-only,
+.marquee .background .desktop-only {
     display: none;
 }
 
@@ -333,42 +310,29 @@ main > .section-outer > .section.width-75 > div {
   width: 75%;
 }
 
-@media screen and (width >= 576px) {
+@media screen and (min-width: 576px) {
     main > .section-outer > .section,
     .block .container {
         max-width: 540px;
     }
 }
 
-@media screen and (width >= 768px) {
+@media screen and (min-width: 768px) {
     main > .section-outer > .section,
     .block .container {
         max-width: 720px;
     }
-
-    .block .background .mobile-only,
-    .block .background .desktop-only {
-        display: none;
-    }
-
-    .block .background .tablet-only {
-        display: block;
-    }
 }
 
-@media screen and (width >= 992px) {
+@media screen and (min-width: 992px) {
     main > .section-outer > .section,
     .block .container {
         max-width: 960px;
     }
 }
 
-@media screen and (width >= 1200px) {
-    main > .section-outer > .section,
-    .block .container {
-        max-width: 1140px;
-    }
-
+/* TODO: This MQ is unconventional */
+@media screen and (min-width: 960px) {
     .block .background .mobile-only,
     .block .background .tablet-only {
         display: none;
@@ -379,7 +343,14 @@ main > .section-outer > .section.width-75 > div {
     }
 }
 
-@media screen and (width >= 1400px) {
+@media screen and (min-width: 1200px) {
+    main > .section-outer > .section,
+    .block .container {
+        max-width: 1140px;
+    }
+}
+
+@media screen and (min-width: 1400px) {
     main > .section-outer > .section,
     .block .container {
         max-width: 1320px;


### PR DESCRIPTION
This adds a new `marquee` block to be used in place of the boilerplate hero. The following features are added...
 - Custom block button decorator 
   - **BOLD** links are 'primary' _ITALIC_ links are 'secondary' button styles. 
   - Additional button classes can be added via a `#_button-{className}` for extensibility. I use `blue` in my example for .primary.blue
 - General block background util function w/ object-position parameter. This allows for per-viewport background images and an optional string for object position ex. `top, right`. Any css color value can also be used in place of an image if authored. 

**Fix** [#12<gh-issue-id>](https://github.com/aemsites/creditacceptance/issues/12)

**Test URLs:**
Before: https://main--creditacceptance--aemsites.aem.page/drafts/rparrish/marquee
After: https://rparrish-hero--creditacceptance--aemsites.aem.page/drafts/rparrish/marquee

**Testing criteria** 
Check that the marquee examples look like the various heros in the live site. Some content in my example isn't exact. 
Note: There is a fixed height of 470px on the marquee as per the examples. 
Additional variants for the `marquee` are... 
- `dark-text` giving the general copy a black text
- `max-width-50, max-width-75, max-width-100, max-width-75-desktop, max-width-100-desktop` - These set the foreground copy container max width styles so they don't go over the bg edge. Default is max-width-50 for mobile and max-width-50-desktop for desktopUp. 
