### PR TITLE
[#28] Block: awards

### DIFF
--- a/blocks/awards/awards.css
+++ b/blocks/awards/awards.css
@@ -33,9 +33,11 @@
 }
 
 .awards > ul > li a img {
-  max-height: 120px;
+  width: 120px;
+  height: 120px;
   margin: 10px;
   object-fit: contain;
+  aspect-ratio: 1 / 1;
 }
 
 @media (width < 960px) {

--- a/blocks/awards/awards.css
+++ b/blocks/awards/awards.css
@@ -1,0 +1,74 @@
+.awards > ul {
+  list-style: none;
+  margin: 0;
+  padding: 24px 0;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.awards > ul > li {
+  box-sizing: border-box;
+  border: 0.52px solid var(--soft-gray);
+  background-color: var(--soft-white);
+  width: 50%;
+}
+
+.awards > ul > li .awards-award-inner:hover .awards-award-image {
+  filter: grayscale(0);
+}
+
+.awards > ul > li > a {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  text-decoration: none;
+}
+
+.awards .awards-award-body {
+  display: none;
+  margin-top: -16px;
+}
+
+.awards > ul > li a img {
+  max-height: 120px;
+  margin: 10px;
+  object-fit: contain;
+}
+
+@media (width < 960px) {
+  main > .section-outer > .section.awards-container {
+    max-width: 100%;
+  }
+}
+
+@media (width >= 960px) {
+  .awards > ul {
+    justify-content: flex-start;
+    gap: 24px;
+  }
+
+  .awards > ul > li {
+    border: 1px solid var(--medium-gray);
+    background-color: var(--pure-white);
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    height: 235px;
+    width: 235px;
+    border-radius: 11px;
+    box-shadow: 0 6px 54px rgb(0 0 0 / 10%), 0 2px 8px rgb(0 0 0 / 13%);
+  }
+
+  .awards .awards-award-image {
+    filter: grayscale(1);
+  }
+
+  .awards > ul > li .awards-award-inner:hover .awards-award-body {
+    display: block;
+  }
+}

--- a/blocks/awards/awards.js
+++ b/blocks/awards/awards.js
@@ -1,0 +1,41 @@
+import { createOptimizedPicture } from '../../scripts/aem.js';
+
+export default function decorate(block) {
+  const ul = document.createElement('ul');
+  [...block.children].forEach((row) => {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(row.innerHTML, 'text/html');
+    const link = doc.querySelector('a');
+    if (!link) return;
+    const a = document.createElement('a');
+    a.href = link.href;
+    a.target = '_blank';
+    const li = document.createElement('li');
+    li.className = 'animation-scale';
+    li.append(a);
+    const wrapper = document.createElement('div');
+    wrapper.className = 'awards-award-inner';
+    a.append(wrapper);
+    while (row.firstElementChild) {
+      wrapper.append(row.firstElementChild);
+    }
+    [...wrapper.children].forEach((div) => {
+      if (div.children.length === 1 && div.querySelector('picture')) {
+        div.className = 'awards-award-image';
+      } else {
+        div.className = 'awards-award-body';
+        const nestedLink = div.querySelector('a');
+        if (nestedLink) {
+          nestedLink.parentNode.innerHTML = nestedLink.innerText;
+        }
+      }
+    });
+    ul.append(li);
+  });
+  ul.querySelectorAll('picture > img').forEach((img) => {
+    const optimizedPicture = createOptimizedPicture(img.src, img.alt, false, [{ width: '127' }]);
+    img.closest('picture').replaceWith(optimizedPicture);
+  });
+  block.textContent = '';
+  block.append(ul);
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -14,6 +14,9 @@
   /* colors */
   --light-color: #f8f8f8;
   --light-gray: #f8f9fa;
+  --soft-gray: #DBDBD6;
+  --soft-white: #FCFCFA;
+  --medium-gray: #DADADA;
   --gold: #ffb800;
   --mustard: #cf9400;
   --secondary-btn-border: #2b4361;
@@ -353,6 +356,17 @@ main > .section-outer > .section.width-75 > div {
     .block .container {
         max-width: 1320px;
     }
+}
+
+.animation-scale {
+  transform: scale(1);
+  transition: transform 0.15s ease-in-out;
+}
+
+@media (width >= 960px ) {
+  .animation-scale:hover {
+    transform: scale(1.05);
+  }
 }
 
 /* section metadata */


### PR DESCRIPTION
This PR includes a new block for _awards_ to support the designs in current Credit Acceptance site. 

Fix #28

Test URLs:

Before: https://main--creditacceptance--aemsites.aem.page/drafts/nrego/awards
After: https://nrego-awards--creditacceptance--aemsites.aem.page/drafts/nrego/awards

Testing criteria: compare awards sections on the current Credit Acceptance site - https://www.creditacceptance.com/about, https://www.creditacceptance.com/careers