### PR TITLE
#75 - Add table block 

### DIFF
--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -1,0 +1,67 @@
+.table {
+    width: 100%;
+    overflow-x: auto;
+}
+
+.table table {
+    width: 100%;
+    max-width: 100%;
+    border-collapse: collapse;
+    font-size: var(--body-font-size-xs);
+}
+
+@media (width >=600px) {
+    .table table {
+        font-size: var(--body-font-size-s);
+    }
+}
+
+@media (width >=900px) {
+    .table table {
+        font-size: var(--body-font-size-m);
+    }
+}
+
+.table table thead tr {
+    border-top: 2px solid #dadada;
+    border-bottom: 2px solid #dadada;
+}
+
+.table table tbody tr {
+    border-bottom: 1px solid #dadada;
+}
+
+.table table th {
+    font-weight: 700;
+}
+
+.table table th,
+.table table td {
+    padding: 0.5em;
+    text-align: left;
+}
+
+.table table th p,
+.table table td p {
+    margin: 0;
+}
+
+.table table td p+p {
+    margin-top: 0.25em;
+}
+
+/* no header variant */
+.table.no-header table tbody tr {
+    border-top: 1px solid #dadada;
+}
+
+/* striped variant */
+.table.striped tbody tr:nth-child(odd) {
+    background-color: var(--light-color);
+}
+
+/* bordered variant */
+.table.bordered table th,
+.table.bordered table td {
+    border: 1px solid #dadada;
+}

--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -1,0 +1,34 @@
+/*
+ * Table Block
+ * Recreate a table
+ * https://www.hlx.live/developer/block-collection/table
+ */
+
+function buildCell(rowIndex) {
+  const cell = rowIndex ? document.createElement('td') : document.createElement('th');
+  if (!rowIndex) cell.setAttribute('scope', 'col');
+  return cell;
+}
+
+export default async function decorate(block) {
+  const table = document.createElement('table');
+  const thead = document.createElement('thead');
+  const tbody = document.createElement('tbody');
+
+  const header = !block.classList.contains('no-header');
+  if (header) table.append(thead);
+  table.append(tbody);
+
+  [...block.children].forEach((child, i) => {
+    const row = document.createElement('tr');
+    if (header && i === 0) thead.append(row);
+    else tbody.append(row);
+    [...child.children].forEach((col) => {
+      const cell = buildCell(header ? i : i + 1);
+      cell.innerHTML = col.innerHTML;
+      row.append(cell);
+    });
+  });
+  block.innerHTML = '';
+  block.append(table);
+}


### PR DESCRIPTION
Currently, there isn't a way for us to render tables because all tables are transformed into blocks. So, adding `table` block to render the actual table that can be used for CA site. 

Importing `table` block  from [**AEM Block Collection**](https://github.com/adobe/aem-block-collection/tree/main/blocks/table)

Fix: #75 

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/fragments/smalla/faqs/managing-text-alerts 
- After: https://table--creditacceptance--aemsites.aem.page/fragments/smalla/faqs/managing-text-alerts

Example of all variants: https://sidekick-library--aem-block-collection--adobe.aem.page/block-collection/table 