### PR TITLE
#11 - Tabs block

### DIFF
--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -62,6 +62,20 @@ main > .section-outer > .section.tabs-container {
     margin: 0;
 }
 
+.tabs-panel ul, 
+.tabs-panel ol {
+    padding: 0 0 0 1rem;
+    margin: 1rem 0;
+}
+
+.tabs-panel li {
+    margin: .5rem 0;
+}
+
+.tabs-panel .button-container {
+    padding-top: .5rem;
+}
+
 @media screen and (width >= 576px) {
     .tabs .tabs-list .container,
     .tabs-panel-copy {

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -1,58 +1,94 @@
-.tabs .tabs-list {
-    display: flex;
-    gap: 0.5ch;
+main > .section-outer > .section.tabs-container {
     max-width: 100%;
-    font-size: var(--body-font-size-xs);
-    overflow-x: auto;
-  }
-  
-  @media (width >= 600px) {
-    .tabs .tabs-list {
-      font-size: var(--body-font-size-s);
-    }
-  }
-  
-  @media (width >= 900px) {
-    .tabs .tabs-list {
-      font-size: var(--body-font-size-m);
-    }
-  }
-  
-  .tabs .tabs-list button {
+    padding: 0;
+    margin: 0;
+}
+
+.tabs .tabs-list {
+    background: linear-gradient(to bottom, rgba(230 230 230 / 0%), rgba(230 230 230 / 100%));
+}
+
+.tabs .tabs-list .container {
+    display: flex;
+    gap: .5rem;
+    margin-bottom: 0;
+}
+
+.tabs .tabs-list .container,
+.tabs-panel-copy {
+    padding-inline: 1rem;
+}
+
+.tabs .tabs-list .container button {
     flex: 0 0 max-content;
     margin: 0;
     border: 1px solid #dadada;
     border-radius: 0;
-    padding: 0.5em;
-    background-color: var(--light-color);
-    color: initial;
+    padding: 12px 8px 8px;
+    background-color: #e8e8e0;
+    color: var(--primary-black);
     font-weight: bold;
     line-height: unset;
+    font-size: 12px;
+    font-family: var(--heading-font-family);
     text-align: initial;
     text-overflow: unset;
     overflow: unset;
     white-space: unset;
     transition: background-color 0.2s;
-  }
+}
   
-  .tabs .tabs-list button p {
-    margin: 0;
-  }
-  
-  
-  .tabs .tabs-list button[aria-selected='true'] {
-    border-bottom: 1px solid var(--background-color);
-    background-color: var(--background-color);
+.tabs .tabs-list .container button[aria-selected='true'] {
+    border-bottom: 1px solid transparent;
+    background-color: white;
     cursor: initial;
-  }
-  
-  .tabs .tabs-panel {
-    margin-top: -1px;
-    padding: 24px;
-    border: 1px solid #dadada;
+}
+
+.tabs .tabs-panel {
     overflow: auto;
-  }
-  
-  .tabs .tabs-panel[aria-hidden='true'] {
+}
+
+.tabs .tabs-panel[aria-hidden='true'] {
     display: none;
-  }
+}
+
+.tabs-panel-flex .tabs-panel-container {
+    display: flex;
+    flex-direction: column-reverse;
+    gap: 1rem;
+}
+
+.tabs-panel-flex .tabs-panel-container .tabs-panel-image p {
+    margin: 0;
+}
+
+@media screen and (width >= 576px) {
+    .tabs .tabs-list .container,
+    .tabs-panel-copy {
+        padding-inline: unset;
+    }
+}
+
+/* TODO: This MQ is unconventional */
+@media screen and (width >= 960px) {
+    .tabs .tabs-list {
+        font-size: var(--body-font-size-m);
+    }
+    
+    .tabs .tabs-list .container {
+        gap: 1rem;
+    }
+
+    .tabs .tabs-list .container button {
+        padding: 16px 24px 8px;
+    }
+
+    .tabs-panel-flex .tabs-panel-container {
+        flex-direction: row;
+    }
+
+    .tabs-panel-flex .tabs-panel-container .tabs-panel-copy,
+    .tabs-panel-flex .tabs-panel-container .tabs-panel-image {
+        flex: 50%;
+    }
+}


### PR DESCRIPTION
This is a MVP update for the tabs block. The authoring remains the same w/ a single block using 2 columns with the 1st col as the tab-list and the 2nd col as the tab-content. 

<img width="625" alt="Screenshot 2025-01-21 at 3 18 21 PM" src="https://github.com/user-attachments/assets/bbcbcc46-3770-45bb-84d7-0cc6fa2ea4e5" />

Fix [#11](https://github.com/aemsites/creditacceptance/issues/11)

Test URLs HP:
- Before: https://main--creditacceptance--aemsites.aem.page/
- After: https://rparrish-tabs--creditacceptance--aemsites.aem.page/

Test URLs Draft:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/rparrish/tabs
- After: https://rparrish-tabs--creditacceptance--aemsites.aem.page/drafts/rparrish/tabs

Testing criteria: Take a look at the homepage and drafts tabs to verify styles and functionality. 

Note: If we want to have content agnostic tab content, meaning any grid/fragment or nested blocks as the tab container we need to re-write this so it uses sections and a tabs block w/ relational page content rather than a single block offering. LMK if you think this is a requirement. Looking around the site it doesn't appear to need this but I may be wrong. Thanks