### PR TITLE
#11 Tabs block w/ Sections

### DIFF
--- a/blocks/tabs-metadata/tabs-metadata.css
+++ b/blocks/tabs-metadata/tabs-metadata.css
@@ -1,0 +1,1 @@
+/* Tabs Metadata */

--- a/blocks/tabs-metadata/tabs-metadata.js
+++ b/blocks/tabs-metadata/tabs-metadata.js
@@ -1,0 +1,3 @@
+const init = () => {};
+
+export default init;

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -3,7 +3,7 @@
     --tabs-border-color: #d8d8d8;
     --tabs-border-hover-color: #acacac;
     --tabs-text-color: #2C2C2C;
-    --tabs-active-text-color: #0000;
+    --tabs-active-text-color: #000;
     --tabs-bg-color: #f1f1f1;
     --tabs-active-bg-color: #fff;
     --tabs-list-bg-gradient: linear-gradient(rgb(200 200 200 / 0%) 10%, rgb(200 200 200 / 90%));
@@ -113,7 +113,7 @@ main > .section-outer > .section.tabs-container {
     background: var(--tabs-list-btn-color);
     border-radius: 4px 4px 0 0;
     border: 1px solid transparent;
-    color: var(--tabs-text-color);
+    color: var(--tabs-active-text-color);
     cursor: pointer;
     float: left;
     font-family: var(--heading-font-family);

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -1,10 +1,9 @@
 :root {
     /* Tab Colors */
-    --tabs-active-color: #1473e6;
     --tabs-border-color: #d8d8d8;
     --tabs-border-hover-color: #acacac;
     --tabs-text-color: #2C2C2C;
-    --tabs-active-text-color: #000000;
+    --tabs-active-text-color: #0000;
     --tabs-bg-color: #f1f1f1;
     --tabs-active-bg-color: #fff;
     --tabs-list-bg-gradient: linear-gradient(rgb(200 200 200 / 0%) 10%, rgb(200 200 200 / 90%));
@@ -25,92 +24,92 @@ main > .section-outer > .section.tabs-container {
     z-index: 1;
 }
 
-  .tabs.xxl-spacing {
+.tabs.xxl-spacing {
     padding: var(--spacing-xxl) 0;
-  }
-  
-  .tabs.xl-spacing {
+}
+
+.tabs.xl-spacing {
     padding: var(--spacing-xl) 0;
-  }
-  
-  .tabs.l-spacing {
+}
+
+.tabs.l-spacing {
     padding: var(--spacing-l) 0;
-  }
-  
-  .tabs.s-spacing {
+}
+
+.tabs.s-spacing {
     padding: var(--spacing-s) 0;
-  }
-  
-  .tabs.xs-spacing {
+}
+
+.tabs.xs-spacing {
     padding: var(--spacing-xs) 0;
-  }
-  
-  .tabs div[role="tablist"] {
+}
+
+.tabs div[role="tablist"] {
     position: relative;
     box-shadow: 0 -1px 0 inset var(--tabs-border-color);
     display: flex;
     z-index: 2;
     margin: 0 var(--spacing-m);
-  
+
     /* ScrollProps - If content exceeds height of container, overflow! */
     overflow: auto;
     overflow-y: hidden;
     scroll-snap-type: x mandatory;
     -ms-overflow-style: none; /* Internet Explorer 10+ */
     scrollbar-width: none; /* Firefox 64 */
-    
+
     /* default bg */
     background: var(--tabs-list-bg-gradient);
-  }
-  
-  .tabs div[role="tablist"]::-webkit-scrollbar {
+}
+
+.tabs div[role="tablist"]::-webkit-scrollbar {
     display: none; /* Safari and Chrome */
-  }
-  
-  .tabs div[role="tablist"] .tab-list-container {
+}
+
+.tabs div[role="tablist"] .tab-list-container {
     display: flex;
     gap: .5rem;
     width: var(--container-width);
     margin: 0 auto;
-  }
-  
-  /* center tabs */
-  .tabs.center > div[role="tablist"]::after,
-  .tabs.center > div[role="tablist"]::before {
+}
+
+/* center tabs */
+.tabs.center > div[role="tablist"]::after,
+.tabs.center > div[role="tablist"]::before {
     content: "";
     margin: auto;
-  }
-  
-  .tabs.center div[role="tablist"] .tab-list-container {
+}
+
+.tabs.center div[role="tablist"] .tab-list-container {
     width: auto;
-  }
-  
-  .tabs .tab-content-container {
+}
+
+.tabs .tab-content-container {
     width: var(--container-width);
     margin: 2rem auto;
-  }
-  
-  /* contained tabs content */
-  [role='tabpanel'] > .section > .content,
-  .tabs.contained .tab-content .tab-content-container {
+}
+
+/* contained tabs content */
+[role='tabpanel'] > .section > .content,
+.tabs.contained .tab-content .tab-content-container {
     width: var(--container-width);
     margin: 0 auto;
-  }
-  
-  .tab-content [role='tabpanel'] .section {
+}
+
+.tab-content [role='tabpanel'] .section {
     position: relative;
-  }
-  
-  .tab-content [role='tabpanel'] .section picture.section-background {
+}
+
+.tab-content [role='tabpanel'] .section picture.section-background {
     z-index: 0;
-  }
-  
-  .tab-content [role='tabpanel'] .section > .content {
+}
+
+.tab-content [role='tabpanel'] .section > .content {
     z-index: 1;
     position: relative;
-  }
-  
-  .tabs div[role="tablist"] button {
+}
+
+.tabs div[role="tablist"] button {
     background: var(--tabs-list-btn-color);
     border-radius: 4px 4px 0 0;
     border: 1px solid transparent;
@@ -124,55 +123,51 @@ main > .section-outer > .section.tabs-container {
     transition: color 0.1s ease-in-out;
     max-width: 200px;
     z-index: 1;
-  }
-  
-  .tabs div[role="tablist"] button:first-of-type {
+}
+
+.tabs div[role="tablist"] button:first-of-type {
     margin-left: 0;
     margin-top: 0;
-  }
-  
-  .tabs div[role="tablist"] button:hover {
+}
+
+.tabs div[role="tablist"] button:hover {
     color: var(--tabs-active-text-color);
-  }
-  
-  .tabs div[role="tablist"] button:active {
-    color: var(--tabs-active-color);
-  }
-  
-  .tabs div[role="tablist"] button[aria-selected="true"] {
+}
+
+.tabs div[role="tablist"] button:active {
+    color: var(--tabs-active-text-color);
+}
+
+.tabs div[role="tablist"] button[aria-selected="true"] {
     background: var(--tabs-active-bg-color);
     border-color: var(--tabs-border-color) var(--tabs-border-color) transparent;
     color: var(--tabs-active-text-color);
-  }
-  
-  
-  /* Section Metadata */
-  .tabs-background-transparent .tabs,
-  .tabs-background-transparent .tabs div[role="tablist"],
-  .tabs-background-transparent .tabs div[role="tablist"] button[aria-selected="true"] {
+}
+
+
+/* Section Metadata */
+.tabs-background-transparent .tabs,
+.tabs-background-transparent .tabs div[role="tablist"],
+.tabs-background-transparent .tabs div[role="tablist"] button[aria-selected="true"] {
     background: transparent;
-  }
-  
-  .tabs-background-transparent .tabs div[role="tablist"] button[aria-selected="true"] {
+}
+
+.tabs-background-transparent .tabs div[role="tablist"] button[aria-selected="true"] {
     border-bottom-color: var(--tabs-active-bg-color);
-  }
+}
   
-  @media screen and (min-width: 600px) {
-  }
-  
-  @media screen and (min-width: 1200px) {
-    
+@media screen and (width >= 960px) {
     .tabs div[role="tablist"] .tab-list-container {
-        gap: 1rem;
+        gap: 2rem;
     }
-    
+
     .tabs div[role="tablist"] button {
-      padding: 18px 18px 8px;
-      line-height: 18px;
+        padding: 18px 18px 8px;
+        line-height: 18px;
     }
-  
+
     .tabs.quiet div[role="tablist"] button {
-      padding-top: 18px;
-      padding-bottom: 18px;
+        padding-top: 18px;
+        padding-bottom: 18px;
     }
-  }
+}

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -102,6 +102,7 @@ main > .section-outer > .section.tabs-container {
 
 .tab-content [role='tabpanel'] .section {
     position: relative;
+    min-height: 260px;
 }
 
 .tab-content [role='tabpanel'] .section picture.section-background {

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -24,26 +24,6 @@ main > .section-outer > .section.tabs-container {
     z-index: 1;
 }
 
-.tabs.xxl-spacing {
-    padding: var(--spacing-xxl) 0;
-}
-
-.tabs.xl-spacing {
-    padding: var(--spacing-xl) 0;
-}
-
-.tabs.l-spacing {
-    padding: var(--spacing-l) 0;
-}
-
-.tabs.s-spacing {
-    padding: var(--spacing-s) 0;
-}
-
-.tabs.xs-spacing {
-    padding: var(--spacing-xs) 0;
-}
-
 .tabs div[role="tablist"] {
     position: relative;
     box-shadow: 0 -1px 0 inset var(--tabs-border-color);

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -6,7 +6,7 @@
     --tabs-active-text-color: #000;
     --tabs-bg-color: #f1f1f1;
     --tabs-active-bg-color: #fff;
-    --tabs-list-bg-gradient: linear-gradient(rgb(200 200 200 / 0%) 10%, rgb(200 200 200 / 90%));
+    --tabs-list-bg-gradient: linear-gradient(rgb(200 200 200 / 0%) 30%, rgb(200 200 200 / 90%));
     --tabs-list-btn-color: #e8e8e0;
 }
   
@@ -69,8 +69,17 @@ main > .section-outer > .section.tabs-container {
 .tabs div[role="tablist"] .tab-list-container {
     display: flex;
     gap: .5rem;
-    width: var(--container-width);
-    margin: 0 auto;
+    width: 100%;
+}
+
+.tabs div[role="tablist"] .tab-list-container,
+.tabs .tab-content-container {
+    margin: 0 1rem;
+    max-width: var(--container-width);
+}
+
+.tabs .tab-content-container {
+    margin-block-start: 2rem;
 }
 
 /* center tabs */
@@ -82,11 +91,6 @@ main > .section-outer > .section.tabs-container {
 
 .tabs.center div[role="tablist"] .tab-list-container {
     width: auto;
-}
-
-.tabs .tab-content-container {
-    width: var(--container-width);
-    margin: 2rem auto;
 }
 
 /* contained tabs content */
@@ -119,7 +123,7 @@ main > .section-outer > .section.tabs-container {
     font-family: var(--heading-font-family);
     font-weight: 600;
     margin-top: 0;
-    padding: 12px 8px 8px;
+    padding: 16px 8px 8px;
     transition: color 0.1s ease-in-out;
     max-width: 200px;
     z-index: 1;
@@ -144,7 +148,6 @@ main > .section-outer > .section.tabs-container {
     color: var(--tabs-active-text-color);
 }
 
-
 /* Section Metadata */
 .tabs-background-transparent .tabs,
 .tabs-background-transparent .tabs div[role="tablist"],
@@ -156,13 +159,21 @@ main > .section-outer > .section.tabs-container {
     border-bottom-color: var(--tabs-active-bg-color);
 }
   
+@media screen and (width >= 576px) {
+    .tabs div[role="tablist"] .tab-list-container,
+    .tabs .tab-content-container {
+        margin-left: auto;
+        margin-right: auto;
+    }
+}
+
 @media screen and (width >= 960px) {
     .tabs div[role="tablist"] .tab-list-container {
-        gap: 2rem;
+        gap: 1.5rem;
     }
 
     .tabs div[role="tablist"] button {
-        padding: 18px 18px 8px;
+        padding: 16px 16px 8px;
         line-height: 18px;
     }
 

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -1,58 +1,178 @@
-.tabs .tabs-list {
-    display: flex;
-    gap: 0.5ch;
+:root {
+    /* Tab Colors */
+    --tabs-active-color: #1473e6;
+    --tabs-border-color: #d8d8d8;
+    --tabs-border-hover-color: #acacac;
+    --tabs-text-color: #2C2C2C;
+    --tabs-active-text-color: #000000;
+    --tabs-bg-color: #f1f1f1;
+    --tabs-active-bg-color: #fff;
+    --tabs-list-bg-gradient: linear-gradient(rgb(200 200 200 / 0%) 10%, rgb(200 200 200 / 90%));
+    --tabs-list-btn-color: #e8e8e0;
+}
+  
+main > .section-outer > .section.tabs-container {
     max-width: 100%;
-    font-size: var(--body-font-size-xs);
-    overflow-x: auto;
-  }
-  
-  @media (width >= 600px) {
-    .tabs .tabs-list {
-      font-size: var(--body-font-size-s);
-    }
-  }
-  
-  @media (width >= 900px) {
-    .tabs .tabs-list {
-      font-size: var(--body-font-size-m);
-    }
-  }
-  
-  .tabs .tabs-list button {
-    flex: 0 0 max-content;
+    padding: 0;
     margin: 0;
-    border: 1px solid #dadada;
-    border-radius: 0;
-    padding: 0.5em;
-    background-color: var(--light-color);
-    color: initial;
-    font-weight: bold;
-    line-height: unset;
-    text-align: initial;
-    text-overflow: unset;
-    overflow: unset;
-    white-space: unset;
-    transition: background-color 0.2s;
-  }
-  
-  .tabs .tabs-list button p {
+}
+
+.tabs {
+    position: relative;
     margin: 0;
+    color: var(--tabs-active-text-color);
+    background-color: var(--tabs-active-bg-color);
+    z-index: 1;
+}
+
+  .tabs.xxl-spacing {
+    padding: var(--spacing-xxl) 0;
   }
   
-  
-  .tabs .tabs-list button[aria-selected='true'] {
-    border-bottom: 1px solid var(--background-color);
-    background-color: var(--background-color);
-    cursor: initial;
+  .tabs.xl-spacing {
+    padding: var(--spacing-xl) 0;
   }
   
-  .tabs .tabs-panel {
-    margin-top: -1px;
-    padding: 24px;
-    border: 1px solid #dadada;
+  .tabs.l-spacing {
+    padding: var(--spacing-l) 0;
+  }
+  
+  .tabs.s-spacing {
+    padding: var(--spacing-s) 0;
+  }
+  
+  .tabs.xs-spacing {
+    padding: var(--spacing-xs) 0;
+  }
+  
+  .tabs div[role="tablist"] {
+    position: relative;
+    box-shadow: 0 -1px 0 inset var(--tabs-border-color);
+    display: flex;
+    z-index: 2;
+    margin: 0 var(--spacing-m);
+  
+    /* ScrollProps - If content exceeds height of container, overflow! */
     overflow: auto;
+    overflow-y: hidden;
+    scroll-snap-type: x mandatory;
+    -ms-overflow-style: none; /* Internet Explorer 10+ */
+    scrollbar-width: none; /* Firefox 64 */
+    
+    /* default bg */
+    background: var(--tabs-list-bg-gradient);
   }
   
-  .tabs .tabs-panel[aria-hidden='true'] {
-    display: none;
+  .tabs div[role="tablist"]::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+  }
+  
+  .tabs div[role="tablist"] .tab-list-container {
+    display: flex;
+    gap: .5rem;
+    width: var(--container-width);
+    margin: 0 auto;
+  }
+  
+  /* center tabs */
+  .tabs.center > div[role="tablist"]::after,
+  .tabs.center > div[role="tablist"]::before {
+    content: "";
+    margin: auto;
+  }
+  
+  .tabs.center div[role="tablist"] .tab-list-container {
+    width: auto;
+  }
+  
+  .tabs .tab-content-container {
+    width: var(--container-width);
+    margin: 2rem auto;
+  }
+  
+  /* contained tabs content */
+  [role='tabpanel'] > .section > .content,
+  .tabs.contained .tab-content .tab-content-container {
+    width: var(--container-width);
+    margin: 0 auto;
+  }
+  
+  .tab-content [role='tabpanel'] .section {
+    position: relative;
+  }
+  
+  .tab-content [role='tabpanel'] .section picture.section-background {
+    z-index: 0;
+  }
+  
+  .tab-content [role='tabpanel'] .section > .content {
+    z-index: 1;
+    position: relative;
+  }
+  
+  .tabs div[role="tablist"] button {
+    background: var(--tabs-list-btn-color);
+    border-radius: 4px 4px 0 0;
+    border: 1px solid transparent;
+    color: var(--tabs-text-color);
+    cursor: pointer;
+    float: left;
+    font-family: var(--heading-font-family);
+    font-weight: 600;
+    margin-top: 0;
+    padding: 12px 8px 8px;
+    transition: color 0.1s ease-in-out;
+    max-width: 200px;
+    z-index: 1;
+  }
+  
+  .tabs div[role="tablist"] button:first-of-type {
+    margin-left: 0;
+    margin-top: 0;
+  }
+  
+  .tabs div[role="tablist"] button:hover {
+    color: var(--tabs-active-text-color);
+  }
+  
+  .tabs div[role="tablist"] button:active {
+    color: var(--tabs-active-color);
+  }
+  
+  .tabs div[role="tablist"] button[aria-selected="true"] {
+    background: var(--tabs-active-bg-color);
+    border-color: var(--tabs-border-color) var(--tabs-border-color) transparent;
+    color: var(--tabs-active-text-color);
+  }
+  
+  
+  /* Section Metadata */
+  .tabs-background-transparent .tabs,
+  .tabs-background-transparent .tabs div[role="tablist"],
+  .tabs-background-transparent .tabs div[role="tablist"] button[aria-selected="true"] {
+    background: transparent;
+  }
+  
+  .tabs-background-transparent .tabs div[role="tablist"] button[aria-selected="true"] {
+    border-bottom-color: var(--tabs-active-bg-color);
+  }
+  
+  @media screen and (min-width: 600px) {
+  }
+  
+  @media screen and (min-width: 1200px) {
+    
+    .tabs div[role="tablist"] .tab-list-container {
+        gap: 1rem;
+    }
+    
+    .tabs div[role="tablist"] button {
+      padding: 18px 18px 8px;
+      line-height: 18px;
+    }
+  
+    .tabs.quiet div[role="tablist"] button {
+      padding-top: 18px;
+      padding-bottom: 18px;
+    }
   }

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -102,7 +102,6 @@ main > .section-outer > .section.tabs-container {
 
 .tab-content [role='tabpanel'] .section {
     position: relative;
-    min-height: 260px;
 }
 
 .tab-content [role='tabpanel'] .section picture.section-background {

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -70,16 +70,8 @@ main > .section-outer > .section.tabs-container {
     display: flex;
     gap: .5rem;
     width: 100%;
-}
-
-.tabs div[role="tablist"] .tab-list-container,
-.tabs .tab-content-container {
     margin: 0 1rem;
     max-width: var(--container-width);
-}
-
-.tabs .tab-content-container {
-    margin-block-start: 2rem;
 }
 
 /* center tabs */
@@ -94,23 +86,9 @@ main > .section-outer > .section.tabs-container {
 }
 
 /* contained tabs content */
-[role='tabpanel'] > .section > .content,
-.tabs.contained .tab-content .tab-content-container {
+[role='tabpanel'] > .section > .content {
     width: var(--container-width);
     margin: 0 auto;
-}
-
-.tab-content [role='tabpanel'] .section {
-    position: relative;
-}
-
-.tab-content [role='tabpanel'] .section picture.section-background {
-    z-index: 0;
-}
-
-.tab-content [role='tabpanel'] .section > .content {
-    z-index: 1;
-    position: relative;
 }
 
 .tabs div[role="tablist"] button {
@@ -160,8 +138,7 @@ main > .section-outer > .section.tabs-container {
 }
   
 @media screen and (width >= 576px) {
-    .tabs div[role="tablist"] .tab-list-container,
-    .tabs .tab-content-container {
+    .tabs div[role="tablist"] .tab-list-container {
         margin-left: auto;
         margin-right: auto;
     }

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -65,7 +65,7 @@ function configTabs(config, rootElem) {
 function decorateTabSections(rootElem) {
   // Tab Sections
   const tabsMeta = rootElem.querySelectorAll('main .section .tabs-metadata');
-  tabsMeta.forEach((meta, i) => {
+  tabsMeta.forEach((meta) => {
     const section = meta.closest('.section-outer');
     const data = {};
     meta.querySelectorAll(':scope > div').forEach((row) => {
@@ -78,7 +78,7 @@ function decorateTabSections(rootElem) {
       section.classList.add('tabpanel');
       section.setAttribute('aria-labelledby', `tab-${data.id}-${data.section}`);
       section.setAttribute('data-block-id', `tabs-${data.id}`);
-      if (i > 0) section.setAttribute('hidden', '');
+      // if (i > 0) section.setAttribute('hidden', '');
     }
   });
 }
@@ -107,8 +107,8 @@ function initTabs(elm, config, rootElem) {
   tabs.forEach((tab) => {
     tab.addEventListener('click', changeTabs);
   });
-  if (config) configTabs(config, rootElem);
   decorateTabSections(rootElem);
+  if (config) configTabs(config, rootElem);
 }
 
 const init = (block) => {

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -1,5 +1,5 @@
 /*
- * tabs - consonant v6
+ * tabs.js
  * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role
  */
 import { createTag } from '../../libs/utils/utils.js';

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -65,7 +65,7 @@ function configTabs(config, rootElem) {
 function decorateTabSections(rootElem) {
   // Tab Sections
   const tabsMeta = rootElem.querySelectorAll('main .section .tabs-metadata');
-  tabsMeta.forEach((meta) => {
+  tabsMeta.forEach((meta, i) => {
     const section = meta.closest('.section-outer');
     const data = {};
     meta.querySelectorAll(':scope > div').forEach((row) => {
@@ -78,7 +78,7 @@ function decorateTabSections(rootElem) {
       section.classList.add('tabpanel');
       section.setAttribute('aria-labelledby', `tab-${data.id}-${data.section}`);
       section.setAttribute('data-block-id', `tabs-${data.id}`);
-      // if (i > 0) section.setAttribute('hidden', '');
+      if (i > 0) section.setAttribute('hidden', '');
     }
   });
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -75,6 +75,9 @@
 
   /* nav height */
   --nav-height: 52px;
+    
+  /* containers */
+  --container-width: 100%;
 }
 
 *, ::before, ::after {
@@ -393,6 +396,7 @@ main > .section-outer > .section.spacing-4 {
     padding-left: 0;
     padding-right: 0;
   }
+  :root {  --container-width: 540px; }
 }
 
 @media screen and (width >= 768px) {
@@ -401,6 +405,7 @@ main > .section-outer > .section.spacing-4 {
     .block .container {
         max-width: 720px;
     }
+    :root { --container-width: 720px; }
 }
 
 @media screen and (width >= 992px) {
@@ -410,6 +415,7 @@ main > .section-outer > .section.spacing-4 {
     .block .container {
         max-width: 960px;
     }
+    :root { --container-width: 960px; }
 }
 
 /* TODO: This MQ is unconventional */
@@ -435,6 +441,7 @@ main > .section-outer > .section.spacing-4 {
     .block .container {
         max-width: 1140px;
     }
+    :root { --container-width: 1140px; }
 }
 
 @media screen and (width >= 1400px) {
@@ -444,4 +451,5 @@ main > .section-outer > .section.spacing-4 {
     .block .container {
         max-width: 1320px;
     }
+    :root { --container-width: 1320px; }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -64,7 +64,8 @@
 
   /* nav height */
   --nav-height: 52px;
-
+  
+  /* containers */
   --container-width: 100%;
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -61,6 +61,8 @@
 
   /* nav height */
   --nav-height: 52px;
+
+  --container-width: 100%;
 }
 
 *, ::before, ::after {
@@ -310,6 +312,8 @@ main > .section-outer > .section.width-75 > div {
     .block .container {
         max-width: 540px;
     }
+
+    :root {  --container-width: 540px; }
 }
 
 @media screen and (width >= 768px) {
@@ -318,6 +322,8 @@ main > .section-outer > .section.width-75 > div {
     .block .container {
         max-width: 720px;
     }
+
+    :root { --container-width: 720px; }
 }
 
 @media screen and (width >= 992px) {
@@ -327,6 +333,8 @@ main > .section-outer > .section.width-75 > div {
     .block .container {
         max-width: 960px;
     }
+
+    :root { --container-width: 960px; }
 }
 
 /* TODO: This MQ is unconventional */
@@ -348,6 +356,8 @@ main > .section-outer > .section.width-75 > div {
     .block .container {
         max-width: 1140px;
     }
+
+    :root { --container-width: 1140px; }
 }
 
 @media screen and (width >= 1400px) {
@@ -357,6 +367,8 @@ main > .section-outer > .section.width-75 > div {
     .block .container {
         max-width: 1320px;
     }
+
+    :root { --container-width: 1320px; }
 }
 
 .animation-scale {


### PR DESCRIPTION
I updated the tabs block to use sections as it's tab-content.
Here's the document relationship example. 
 - Tab-list is a list in the first block row
 - Id key is a required tabID to associate the related `tab-metadata` with the following params
 -- key: tabID
 -- section: Index of tab-list association
(Im open to different names, just LMK)

<img width="684" alt="Screenshot 2025-01-22 at 1 55 18 PM" src="https://github.com/user-attachments/assets/eb3b9da0-f9c0-40f0-8efb-bdc4b88e849a" />

I am using a new `tabs-metadata` table for this association. I had originally tried using `section-metadata tab: {tabId}, {index}` but I ran into race conditions where the section-meta is removed and the blocks vs section decorators are decorated async so the tabs block query selectors weren't reliable. This could be refactored w/ a section promise, but It felt intrusive as a site whole for this feature. LMK if you have any thoughts on the approach I took

Note: this PR is just the tabs functionality adding the tabList UI and relational section(s). The layouts in the tab content will be reliant on authoring, whether it be plain content, fragment, column, grid layout (future) etc. 

The [HP](https://rparrish-tabs2--creditacceptance--aemsites.aem.page/) will look broken on these testing urls. Once this is merged, I will update the index page document so that it reflects this pattern and create a template in the library. 

Fix #[11](https://github.com/aemsites/creditacceptance/issues/11)

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/rparrish/tabs2
- After: https://rparrish-tabs2--creditacceptance--aemsites.aem.page/drafts/rparrish/tabs2

Testing criteria - Check that the tabs UI works and looks the same as the [live site](https://www.creditacceptance.com/). 
