### PR TITLE
Smalla/faqs

### DIFF
--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -1,8 +1,3 @@
-
-.accordion-container {
-    padding-inline: 16px;
-}
-
 .accordion details {
     border: 1px solid #dadada;
     border-radius: 6px;

--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -40,7 +40,7 @@ function buildAccordionSection(section) {
 
   const heading = section.querySelector('h1,h2');
   const defaultContentWrapper = createTag('div', { class: 'default-content-wrapper' }, heading);
-  const accordion = createTag('div', { class: 'accordion' });
+  const accordion = createTag('div', { class: 'accordion faqs block', 'data-block-name': 'accordion' });
   const accordionWrapper = createTag('div', { class: 'accordion-wrapper' }, accordion);
 
   const accordionItemLabels = Array.from(section.querySelectorAll('h3,h4,h5,h6'));
@@ -58,6 +58,8 @@ function buildAccordionSection(section) {
     const accordionItemRow = createTag('div', null, [accordionItemLabelCol, accordionItemContentCol]);
 
     accordion.append(accordionItemRow);
+
+    accordion.dataset.blockStatus = 'loaded';
   });
 
   section.innerHTML = '';

--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -1,33 +1,96 @@
-/*
- * Accordion Block
- * Recreate an accordion
- * https://www.hlx.live/developer/block-collection/accordion
- */
+import { loadFragment } from '../fragment/fragment.js';
+import { createTag } from '../../libs/utils/utils.js';
 
-export default function decorate(block) {
+function decorate(block) {
   [...block.children].forEach((row) => {
-    // decorate accordion item label
     const label = row.children[0];
-    const summary = document.createElement('summary');
-    summary.className = 'accordion-item-label';
-    summary.append(...label.childNodes);
+    const summary = createTag('summary', { class: 'accordion-item-label' }, [...label.childNodes]);
 
-    const plus = document.createElement('span');
-    plus.className = 'accordion-item-plus';
-    plus.textContent = '+';
-
-    const minus = document.createElement('span');
-    minus.className = 'accordion-item-minus';
-    minus.textContent = '-';
+    const plus = createTag('span', { class: 'accordion-item-plus' }, '+');
+    const minus = createTag('span', { class: 'accordion-item-minus' }, '-');
     summary.prepend(plus, minus);
 
-    // decorate accordion item body
     const body = row.children[1];
     body.className = 'accordion-item-body';
-    // decorate accordion item
-    const details = document.createElement('details');
-    details.className = 'accordion-item';
-    details.append(summary, body);
+
+    const details = createTag('details', { class: 'accordion-item' }, [summary, body]);
     row.replaceWith(details);
   });
+}
+
+function rearrangeSectionContents(section) {
+  Array.from(section.children).forEach((child) => {
+    if (!child?.classList.contains('default-content-wrapper')) {
+      child.previousElementSibling?.append(child);
+    } else if (child?.classList.contains('default-content-wrapper') && !child?.firstElementChild.matches('h2,h3,h4,h5,h6')) {
+      const contents = [child.firstElementChild];
+      let nextElement = child.firstElementChild?.nextElementSibling;
+
+      while (nextElement && !nextElement.matches('h3,h4,h5,h6')) {
+        contents.push(nextElement);
+        nextElement = nextElement.nextElementSibling;
+      }
+      child.previousElementSibling?.append(...contents);
+    }
+  });
+}
+
+function buildAccordionSection(section) {
+  rearrangeSectionContents(section);
+
+  const heading = section.querySelector('h1,h2');
+  const defaultContentWrapper = createTag('div', { class: 'default-content-wrapper' }, heading);
+  const accordion = createTag('div', { class: 'accordion' });
+  const accordionWrapper = createTag('div', { class: 'accordion-wrapper' }, accordion);
+
+  const accordionItemLabels = Array.from(section.querySelectorAll('h3,h4,h5,h6'));
+  accordionItemLabels.forEach((label) => {
+    let content = label.nextElementSibling;
+    const contentElements = [];
+
+    while (content && !accordionItemLabels.includes(content)) {
+      contentElements.push(content);
+      content = content.nextElementSibling;
+    }
+
+    const accordionItemLabelCol = createTag('div', null, [label]);
+    const accordionItemContentCol = createTag('div', null, [...contentElements]);
+    const accordionItemRow = createTag('div', null, [accordionItemLabelCol, accordionItemContentCol]);
+
+    accordion.append(accordionItemRow);
+  });
+
+  section.innerHTML = '';
+  section.append(defaultContentWrapper, accordionWrapper);
+}
+
+async function decorateFAQs(block) {
+  const fragment = block.querySelector('a');
+  if (!fragment) return;
+
+  const path = fragment.getAttribute('href');
+  const content = await loadFragment(path);
+  const fragmentSection = content.querySelector('.section');
+
+  if (!fragmentSection) return;
+
+  buildAccordionSection(fragmentSection);
+  fragmentSection.querySelectorAll('.accordion').forEach((accordion) => {
+    decorate(accordion);
+  });
+
+  const blockSection = block.closest('.section');
+  blockSection.classList.add(...fragmentSection.classList);
+
+  block.closest('.accordion-wrapper').replaceWith(...fragmentSection.childNodes);
+  fragmentSection.remove();
+}
+
+export default async function init(block) {
+  if (block.classList.contains('faqs')) {
+    await decorateFAQs(block);
+    return;
+  }
+
+  decorate(block);
 }


### PR DESCRIPTION
This block variant `accordion (faqs)` allows authors to create accordions for FAQs where the content item can use other blocks and rich content. `h1,h1` treated as primary heading of the FAQs section, `h2,h3,h4,h5,h6` are the accordion labels/title and act as a separator to other accordion item within that FAQs section. All other contents are the content items. 

Fix #40

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/smalla/faq/customer-faq
- After: https://smalla-faqs--creditacceptance--aemsites.aem.page/drafts/smalla/faq/customer-faq 

Testing criteria - To test if the rich content is decorated as default accordion items, visual comparision with https://www.creditacceptance.com/customers/faq, https://www.creditacceptance.com/dealers/faq