### PR TITLE
#50 - Main navigation - Mobile and Desktop in one doc. No duplicate links/code

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1,6 +1,11 @@
 /* stylelint-disable no-descending-specificity */
 
 header {
+  --menu-bg: #f7f9fb;
+  --menu-bg-hover: #f2f2f2;
+  --menu-accent-gray: #ccc;
+  --menu-accent-orange: #ffb800;
+
     background-color: var(--light-gray);
 
     nav {
@@ -13,14 +18,19 @@ header {
       background-color: var(--light-gray);
     }
     p { margin: 0; }
+
+    .default-content-wrapper {
+      max-width: var(--container-width);
+      margin: 0 auto;
+      position: relative;
+    }
+    
 }
 
 /* brand */
 header .nav-brand {
-  grid-area: brand;
   flex-basis: 100%;
   text-align: center;
-  position: relative;
   
   .icon {
     width: 150px;
@@ -42,7 +52,8 @@ header .nav-brand {
   }
 
   .btn-user {
-    margin-top: 4px;
+    display: flex;
+    align-content: center;
   }
 
   .btn-ham {
@@ -110,12 +121,19 @@ header .nav-brand {
 
 /* nav brand */
 .nav-brand .default-content-wrapper {
+  height: 100%;
+
   a {
-    height: 100%;
-    display: inline-flex;
-    align-content: center;
-    flex-wrap: wrap;
+    margin: 0;
   }
+  
+  p {
+    display: flex;
+    place-content: center;
+  }
+  
+  p,
+  .icon { height: 100%; }
 }
 
 .nav-main,
@@ -133,16 +151,24 @@ header .nav-brand {
   details {
     summary {
       padding: 1rem 0 1rem 2rem;
-      border: 1px dotted var(--dark-gray);
+      border: 1px dotted var(--menu-accent-gray);
       border-width: 1px 0;
       position: relative;
+      overflow: hidden;
       font-size: 13px;
+      display: block;
     }
     
     ul {
       list-style: none;
       padding: .5rem 0;
       margin: 0 0 0 2rem;
+    }
+    
+    li {
+      position: relative;
+      overflow: hidden;
+      z-index: 0;
     }
 
     li > a {
@@ -181,7 +207,17 @@ header .nav-brand {
   
   details[open] > summary::before {
     content: "-";
-  }  
+  }
+    
+  span.ripple {
+    position: absolute;
+    border-radius: 50%;
+    transform: scale(0);
+    animation: ripple 800ms ease-out;
+    background-color: var(--menu-accent-gray);
+    z-index: -1;
+  }
+
 }
 
 .nav-quick-links {
@@ -189,20 +225,19 @@ header .nav-brand {
 
   .default-content-wrapper,
   h1, h2, h3, h4, h5, h6 {
-    margin: 0;
     font-family: var(--ff-acceptance-regular);
     font-size: 20px;
   }
   
   .quick-links nav {
     padding: 0;
+    width: var(--container-width)
   }
 }
 
 /* nav tools */
 .nav-tools {
   padding: 1rem 0;
-  margin: 0 2rem;
   
   a {
     display: inline-block;
@@ -213,6 +248,7 @@ header .nav-brand {
 
   .button-container {
     display: none;
+    line-height: 0;
 
     .button {
       line-height: 1px;
@@ -234,7 +270,7 @@ header .nav-brand {
 
   header .nav-brand {
     text-align: unset;
-    flex-basis: 200px;
+    flex-basis: 160px;
   }
 
   header .nav-main .default-content-wrapper,
@@ -250,12 +286,8 @@ header .nav-brand {
   }
 
   /* nav brand */
-  .nav-brand .default-content-wrapper {
+  .nav-brand a {
     height: 100%;
-
-    p {
-      height: 100%;
-    }
   }
 
   /* nav main */
@@ -264,7 +296,7 @@ header .nav-brand {
       position: relative;
 
         summary {
-          padding: 0 2rem 0 1em;
+          padding: 0 2.5rem 0 2em;
           border: none;
           height: 100%;
           display: flex;
@@ -278,11 +310,25 @@ header .nav-brand {
           left: 0;
           background: white;
           margin: 0;
-          padding: .5rem 1rem;
+          padding: 0 0 1rem;
+          border-radius: 0 0 4px 4px;
           box-shadow: 0 2px 6px #0000001f, 0 4px 25px #00000024;
           
           li {
-            min-width: 245px;
+            min-width: 270px;
+            background: var(--menu-bg);
+            margin: 0;
+            padding: 0 1rem;
+
+            a { 
+              padding: .75rem 0;
+              border-bottom: 1px dotted var(--dark-gray);
+              white-space: nowrap;
+            }
+          }
+          
+          li:hover {
+            background: var(--menu-bg-hover);
           }
         }
     }
@@ -295,7 +341,10 @@ header .nav-brand {
     
     summary:hover,
     details[open] summary {
-      background: var(--soft-gray)
+      background: var(--menu-bg-hover);
+      border-radius: 0 0 4px 4px;
+      box-shadow: 0 4px var(--menu-accent-orange);
+      z-index: 1;
     }
 
     summary:hover > ul {
@@ -304,7 +353,7 @@ header .nav-brand {
 
 
     details > summary::before {
-      right: 14px;
+      right: 1.5rem;
       margin-top: -4px;
       left: auto;
       content: '\2304';
@@ -320,13 +369,12 @@ header .nav-brand {
   header .nav-tools {
     margin: 0 0 0 auto;
     padding: 0;
-    display: flex;
     align-content: center;
 
     .default-content-wrapper {
       height: auto;
     }
-    
+
     a {
       font-size: 12px;
       padding: 0;
@@ -343,9 +391,16 @@ header .nav-brand {
   }
 
   /* hide elements */
-  .nav-brand .btn-mobile,
+  .nav-brand .default-content-wrapper .btn-mobile,
   .nav-quick-links[aria-expanded='false'],
   .nav-quick-links[aria-expanded='true'] {
     display: none;
+  }
+}
+
+@keyframes ripple {
+  to {
+    transform: scale(3);
+    opacity: 0;
   }
 }

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1,416 +1,351 @@
-/* stylelint-disable color-function-notation */
 /* stylelint-disable no-descending-specificity */
 
-/* header and nav layout */
-header .nav-wrapper {
-  background-color: var(--light-gray);
-  width: 100%;
-  z-index: 2;
-}
+header {
+    background-color: var(--light-gray);
 
-header nav {
-  box-sizing: border-box;
-  display: grid;
-  grid-template:
-    'hamburger brand tools' var(--nav-height)
-    'sections sections sections' 1fr / auto 1fr auto;
-  align-items: center;
-  gap: 0 24px;
-  margin: auto;
-  height: var(--nav-height);
-  padding: 0 12px;
-  font-family: var(--body-font-family);
-}
-
-header nav > * {
-  margin: auto 0;
-
-  p, dl, ol, ul, pre, blockquote {
-    margin: auto 0;
-  }
-}
-
-header nav[aria-expanded='true'] {
-  grid-template:
-    'hamburger brand' var(--nav-height)
-    'sections sections' 1fr
-    'tools tools' var(--nav-height) / auto 1fr;
-  overflow-y: auto;
-  min-height: 100dvh;
-}
-
-header .nav-brand .icon {
-  width: 150px;
-  height: 35px;
-}
-
-/* tools */
-header nav .nav-tools {
-  display: none;
-  grid-area: tools;
-
-  > .section > .default-content-wrapper{
-    display: flex;
-    gap: 20px;
-  }
-
-  ul {
-    display: flex;
-    gap: 10px;
-  }
-
-  li {
-    list-style: none;
-  }
-
-  .button {
-    line-height: 1px;
-    padding: 12px !important;
-    font-size: 10px;
-    font-weight: 700;
-    letter-spacing: .33px;
-    margin-left: 30px;
-  }
-}
-
-header nav p {
-  line-height: 1;
-}
-
-header nav a:any-link {
-  color: currentcolor;
-}
-
-/* hamburger */
-header nav .nav-hamburger {
-  grid-area: hamburger;
-  height: 22px;
-  display: flex;
-  align-items: center;
-}
-
-header nav .nav-hamburger button {
-  height: 22px;
-  margin: 0;
-  border: 0;
-  border-radius: 0;
-  padding: 0;
-  background-color: var(--background-color);
-  color: inherit;
-  overflow: initial;
-  text-overflow: initial;
-  white-space: initial;
-}
-
-header nav .nav-hamburger-icon,
-header nav .nav-hamburger-icon::before,
-header nav .nav-hamburger-icon::after {
-  box-sizing: border-box;
-  display: block;
-  position: relative;
-  width: 20px;
-}
-
-header nav .nav-hamburger-icon::before,
-header nav .nav-hamburger-icon::after {
-  content: '';
-  position: absolute;
-  background: currentcolor;
-}
-
-header nav[aria-expanded='false'] .nav-hamburger-icon,
-header nav[aria-expanded='false'] .nav-hamburger-icon::before,
-header nav[aria-expanded='false'] .nav-hamburger-icon::after {
-  height: 2px;
-  border-radius: 2px;
-  background: currentcolor;
-}
-
-header nav[aria-expanded='false'] .nav-hamburger-icon::before {
-  top: -6px;
-}
-
-header nav[aria-expanded='false'] .nav-hamburger-icon::after {
-  top: 6px;
-}
-
-header nav[aria-expanded='true'] .nav-hamburger-icon {
-  height: 22px;
-}
-
-header nav[aria-expanded='true'] .nav-hamburger-icon::before,
-header nav[aria-expanded='true'] .nav-hamburger-icon::after {
-  top: 3px;
-  left: 1px;
-  transform: rotate(45deg);
-  transform-origin: 2px 1px;
-  width: 24px;
-  height: 2px;
-  border-radius: 2px;
-}
-
-header nav[aria-expanded='true'] .nav-hamburger-icon::after {
-  top: unset;
-  bottom: 3px;
-  transform: rotate(-45deg);
+    nav {
+      padding: 0.5rem 1rem;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      z-index: 2;
+      position: relative;
+      background-color: var(--light-gray);
+    }
+    p { margin: 0; }
 }
 
 /* brand */
 header .nav-brand {
   grid-area: brand;
-  flex-basis: 128px;
-  font-size: var(--heading-font-size-s);
-  font-weight: 700;
-  line-height: 1;
+  flex-basis: 100%;
+  text-align: center;
+  position: relative;
+  
+  .icon {
+    width: 150px;
+    height: 35px;
+  }
+
+  .btn-mobile {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    left: 0;
+    background: none;
+    border: none;
+  }
+  
+  .btn-mobile:hover,
+  .btn-mobile:active {
+    background: none;
+  }
+
+  .btn-user {
+    margin-top: 4px;
+  }
+
+  .btn-ham {
+    right: 0;
+    left: unset;
+    background: none;
+    border: none;
+  }
+
+  .btn-ham:hover {
+    cursor: pointer;
+  }
 }
 
-header nav .nav-brand img {
-  width: auto;
-  height: auto;
+.icon-ham {
+  height: 24px;
+  width: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  position: relative;
+
+  span {
+    display: block;
+    position: absolute;
+    background: var(--dark-gray);
+    height: 2px;
+    width: 100%;
+    transform-origin: center center;
+  }
+
+  span:nth-child(1) { top: 2px; }
+
+  span:nth-child(2) { 
+    top: 50%; 
+    margin-top: -1px; 
+  }
+  
+  span:nth-child(3) { 
+    top: 50%; 
+    margin-top: -1px; 
+  }
+  
+  span:nth-child(4) { bottom: 2px; }
 }
 
-/* sections */
-header nav .nav-sections {
-  grid-area: sections;
-  flex: 1 1 auto;
+.icon-ham:hover span {
+    background: var(--pure-black);
+}
+
+.btn-ham[aria-expanded='true'] .icon-ham {
+  transform: rotate(45deg);
+  
+  span:nth-child(2) { transform: rotate(90deg) }
+  
+  span:nth-child(1),
+  span:nth-child(4) { display: none; }
+}
+
+
+/* nav sections */
+.nav-section[aria-expanded='false'] {
   display: none;
-  visibility: hidden;
 }
 
-header nav[aria-expanded='true'] .nav-sections {
-  display: block;
-  visibility: visible;
-  align-self: start;
+/* nav brand */
+.nav-brand .default-content-wrapper {
+  a {
+    height: 100%;
+    display: inline-flex;
+    align-content: center;
+    flex-wrap: wrap;
+  }
 }
 
-header nav .nav-sections ul {
-  list-style: none;
-  padding-left: 0;
-  font-size: var(--body-font-size-s);
-}
-
-header nav .nav-sections ul > li:hover{
-  color: var(--black-olive);
-}
-
-header nav .nav-sections ul > li > span, 
-header .nav-tools li > a,
-header nav a.link {
-  font-weight: 600;
+.nav-main,
+.nav-tools {
   color: var(--black-olive);
   font-size: 12px;
   font-family: var(--ff-acceptance-demi-bold);
   text-transform: uppercase;
   letter-spacing: 0.7px;
-  line-height: 22px;
-  text-decoration: none;
+  line-height: 20px;
 }
 
-header nav .nav-sections ul > li > ul > li {
-  font-weight: 400;
-}
+.nav-main {
+  /* accordion */
+  details {
+    summary {
+      padding: 1rem 0 1rem 2rem;
+      border: 1px dotted var(--dark-gray);
+      border-width: 1px 0;
+      position: relative;
+      font-size: 13px;
+    }
+    
+    ul {
+      list-style: none;
+      padding: .5rem 0;
+      margin: 0 0 0 2rem;
+    }
 
-header .nav-tools li > a {
-  font-family: var(--heading-font-family);
-}
-
-.nav-secondary {
-  display: none;
-}
-
-@media (width >= 960px) {
-  header nav .nav-hamburger {
-    display: none;
-    visibility: hidden;
-  }
-
-  header nav {
-    display: flex;
-    justify-content: space-between;
-    gap: 0 32px;
-  }
-
-  header nav .nav-tools {
-    display: block;
-  }
-
-  header nav[aria-expanded='true'] {
-    min-height: 0;
-    overflow: visible;
-  }
-
-  header nav .nav-sections {
-    display: block;
-    visibility: visible;
-    white-space: nowrap;
-    height: 100%;
-
-    > .section{
-      height: 100%;
-
-      > .default-content-wrapper {
-        height: 100%;
-
-        >ul {
-          height: 100%;
-
-          >li , >li > span {
-            height: 100%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            position: relative;
-          }
-
-            > li {
-            padding: 0 16px;
-            }
-
-            > li:hover {
-                background-color: rgba(0, 0, 0, 10%);
-                box-shadow: 0 4px #ffb800;
-                border-radius: 4px;
-            }
-        }
-      }
+    li > a {
+      display: inline-block;
+      width: 100%;
+      padding: 0.5rem 0;
     }
   }
 
-  header nav[aria-expanded='true'] .nav-sections {
-    align-self: unset;
-  }
-
-  header nav .nav-sections .nav-drop {
-    position: relative;
-    padding-right: 16px;
+  details summary:hover {
     cursor: pointer;
   }
 
-  header nav .nav-sections .nav-drop span::after {
-    position: relative;
-    content: '';
-    right: 2px;
-    left: 5px;
-    transform: rotate(135deg);
-    width: 6px;
-    height: 6px;
-    border: 2px solid currentcolor;
-    border-radius: 0 1px 0 0;
-    border-width: 2px 2px 0 0;
+  details:nth-child(1) > summary {
+    border-bottom-width: 0;
   }
 
-  header nav .nav-sections .nav-drop[aria-expanded='true']::after {
-    top: unset;
-    bottom: 0.5em;
-    transform: rotate(315deg);
+  details[open]:nth-child(1) > summary {
+    border-bottom-width: 1px;
+  }
+  
+  details > summary:first-of-type,
+  details[open] > summary:first-of-type {
+    list-style-type: none;
   }
 
-  header nav .nav-sections ul {
-    display: flex;
-    margin: 0;
-  }
-
-  header nav .nav-sections .default-content-wrapper > ul > li {
-    flex: 0 1 auto;
-    position: relative;
-  }
-
-  header nav .nav-sections .default-content-wrapper > ul > li > span > ul, .nav-secondary {
-    display: none;
-    position: relative;
-  }
-
-  header nav .nav-sections .default-content-wrapper > ul > li[aria-expanded='true'] > span > ul {
-    display: block;
+  details > summary::before {
     position: absolute;
-    left: -24px;
-    width: 200px;
-    top: 150%;
-    padding: 16px;
-    background-color: var(--light-color);
-    white-space: initial;
-  }
-
-  header nav .nav-sections .default-content-wrapper > ul > li[aria-expanded='true'] > .nav-secondary {
-    display: block;
-    position: absolute;
-    background-color: var(--light-color);
-    white-space: initial;
-    opacity: 0;
-    transform: translateY(-10px);
-    animation: fade-in 0.3s forwards;
-  }
-
-  @keyframes fade-in {
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-
-  header nav .nav-sections .default-content-wrapper > ul > li > ul::before {
-    content: '';
-    position: absolute;
-    top: -8px;
-    left: 16px;
-    width: 0;
-    height: 0;
-    border-left: 8px solid transparent;
-    border-right: 8px solid transparent;
-    border-bottom: 8px solid var(--light-color);
-  }
-
-  header nav .nav-sections .default-content-wrapper > ul > li > ul > li {
-    padding: 8px 0;
-  }
-
-  /* Secondary Nav */
-  .nav-secondary {
-    position: absolute;
-    top: calc(var(--nav-height) + 4px);
-    background-color: white;
+    top: 50%;
     left: 0;
-    min-width: fit-content;
-    padding-bottom: 20px;
-    box-shadow: 0 5px 5px -3px #0003,0 8px 10px 1px #00000024,0 3px 14px 2px #0000001f;
-    z-index: 100;
+    content: '+';
+    font-size: 2rem;
+    line-height: 0;
+    font-family: 'Courier New', Courier, monospace;
+  }
+  
+  details[open] > summary::before {
+    content: "-";
+  }  
+}
 
-    :has(.columns){
-      min-width: 600px;
-    }
+.nav-quick-links {
+  margin: 1rem 0;
 
-    .section {
-      margin: 0 !important;
-    }
-    
-    a.link:any-link {
-      display: block;
-      padding: .5rem 0;
-      font-family: var(--ff-acceptance-demi-bold);
-      font-weight: var(--font-weight-bold);
-      color: black;
-      line-height: 24px;
-      text-align: left;
-      white-space: nowrap;
-      cursor: pointer !important;
-      text-decoration: none;
-    }
+  .default-content-wrapper,
+  h1, h2, h3, h4, h5, h6 {
+    margin: 0;
+    font-family: var(--ff-acceptance-regular);
+    font-size: 20px;
+  }
+  
+  .quick-links nav {
+    padding: 0;
+  }
+}
 
-    a.link:hover:hover {
-      background-color: var(--light-gray) !important;
-    }
+/* nav tools */
+.nav-tools {
+  padding: 1rem 0;
+  margin: 0 2rem;
+  
+  a {
+    display: inline-block;
+    width: 100%;
+    padding: 0.25rem 0;
+    font-size: 13px;
+  }
 
-    .button-container {
-      margin: 0 1rem 0.5rem;
-      background-color: var(--light-gray);
-      border-bottom: 1px dotted #000;
-      box-sizing: border-box;
-    }
+  .button-container {
+    display: none;
 
-    .columns > div {
-      gap:0;
+    .button {
+      line-height: 1px;
+      padding: 12px;
+      font-size: 10px;
+      letter-spacing: .33px;
     }
   }
 }
 
+@media (width >= 960px) {
+  /* brand */
+  header nav {
+    flex-direction: row;
+    height: var(--nav-height);
+    padding-top: 0;
+    padding-bottom: 0;
+  }
 
+  header .nav-brand {
+    text-align: unset;
+    flex-basis: 200px;
+  }
+
+  header .nav-main .default-content-wrapper,
+  header .nav-tools .default-content-wrapper {
+    display: flex;
+    gap: 1rem;
+    height: 100%;
+    align-content: center;
+  }
+
+  header .nav-main .default-content-wrapper {
+    gap: 0;
+  }
+
+  /* nav brand */
+  .nav-brand .default-content-wrapper {
+    height: 100%;
+
+    p {
+      height: 100%;
+    }
+  }
+
+  /* nav main */
+  .nav-main {
+    details {
+      position: relative;
+
+        summary {
+          padding: 0 2rem 0 1em;
+          border: none;
+          height: 100%;
+          display: flex;
+          align-content: center;
+          flex-wrap: wrap;
+        }
+        
+        ul {
+          position: absolute;
+          top: 100%;
+          left: 0;
+          background: white;
+          margin: 0;
+          padding: .5rem 1rem;
+          box-shadow: 0 2px 6px #0000001f, 0 4px 25px #00000024;
+          
+          li {
+            min-width: 245px;
+          }
+        }
+    }
+
+    .detail-0 ul {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      grid-gap: 0 1rem;
+    }
+    
+    summary:hover,
+    details[open] summary {
+      background: var(--soft-gray)
+    }
+
+    summary:hover > ul {
+      display: block;
+    }
+
+
+    details > summary::before {
+      right: 14px;
+      margin-top: -4px;
+      left: auto;
+      content: '\2304';
+      font-size: 1.2rem;
+    }
+    
+    details[open] > summary::before {
+      content: "\2304";
+    }  
+  }
+  
+  /* nav tools */
+  header .nav-tools {
+    margin: 0 0 0 auto;
+    padding: 0;
+    display: flex;
+    align-content: center;
+
+    .default-content-wrapper {
+      height: auto;
+    }
+    
+    a {
+      font-size: 12px;
+      padding: 0;
+    }
+  }
+
+  /* show elements */
+  .nav-section[aria-expanded='false'] {
+    display: block;
+  } 
+  
+  .nav-tools .button-container {
+    display: inline;
+  }
+
+  /* hide elements */
+  .nav-brand .btn-mobile,
+  .nav-quick-links[aria-expanded='false'],
+  .nav-quick-links[aria-expanded='true'] {
+    display: none;
+  }
+}

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,121 +1,83 @@
 import { getMetadata } from '../../scripts/aem.js';
 import { loadFragment } from '../fragment/fragment.js';
+import { createTag } from '../../libs/utils/utils.js';
 
 // media query match that indicates mobile/tablet width
-const isDesktop = window.matchMedia('(min-width: 900px)');
+const isDesktop = window.matchMedia('(min-width: 960px)');
+const icons = {
+  user: 'https://main--creditacceptance--aemsites.aem.page/icons/user.svg',
+};
 
-function closeOnEscape(e) {
-  if (e.code === 'Escape') {
-    const nav = document.getElementById('nav');
-    const navSections = nav.querySelector('.nav-sections');
-    const navSectionExpanded = navSections.querySelector('[aria-expanded="true"]');
-    if (navSectionExpanded && isDesktop.matches) {
-      // eslint-disable-next-line no-use-before-define
-      toggleAllNavSections(navSections);
-      navSectionExpanded.focus();
-    } else if (!isDesktop.matches) {
-      // eslint-disable-next-line no-use-before-define
-      toggleMenu(nav, navSections);
-      nav.querySelector('button').focus();
+function decorateMainMenu(section) {
+  const navHeaders = section.querySelectorAll('h3');
+  if (!navHeaders) return;
+  [...navHeaders].forEach((navHeader, i) => {
+    const summaryTag = createTag('summary', { class: 'nav-summary' }, navHeader.textContent);
+    const details = createTag('details', { class: `nav-detail detail-${i}` }, summaryTag);
+    navHeader.replaceWith(details);
+    const list = details.nextElementSibling;
+    if (!list) return;
+    details.append(list);
+
+    /* toggle on mouseover in desktop */
+    if (isDesktop.matches) {
+      details.addEventListener('mouseover', () => {
+        details.setAttribute('open', '');
+      });
+      details.addEventListener('mouseout', () => {
+        details.removeAttribute('open');
+      });
     }
-  }
-}
-
-function closeOnFocusLost(e) {
-  const nav = e.currentTarget;
-  if (!nav.contains(e.relatedTarget)) {
-    const navSections = nav.querySelector('.nav-sections');
-    const navSectionExpanded = navSections.querySelector('[aria-expanded="true"]');
-    if (navSectionExpanded && isDesktop.matches) {
-      // eslint-disable-next-line no-use-before-define
-      toggleAllNavSections(navSections, false);
-    } else if (!isDesktop.matches) {
-      // eslint-disable-next-line no-use-before-define
-      toggleMenu(nav, navSections, false);
-    }
-  }
-}
-
-function openOnKeydown(e) {
-  const focused = document.activeElement;
-  const isNavDrop = focused.className === 'nav-drop';
-  if (isNavDrop && (e.code === 'Enter' || e.code === 'Space')) {
-    const dropExpanded = focused.getAttribute('aria-expanded') === 'true';
-    // eslint-disable-next-line no-use-before-define
-    toggleAllNavSections(focused.closest('.nav-sections'));
-    focused.setAttribute('aria-expanded', dropExpanded ? 'false' : 'true');
-  }
-}
-
-function focusNavSection() {
-  document.activeElement.addEventListener('keydown', openOnKeydown);
-}
-
-/**
- * Toggles all nav sections
- * @param {Element} sections The container element
- * @param {Boolean} expanded Whether the element should be expanded or collapsed
- */
-function toggleAllNavSections(sections, expanded = false) {
-  sections.querySelectorAll('.nav-sections .default-content-wrapper > ul > li').forEach((section) => {
-    section.setAttribute('aria-expanded', expanded);
   });
 }
 
-/**
- * Toggles the entire nav
- * @param {Element} nav The container element
- * @param {Element} navSections The nav sections within the container element
- * @param {*} forceExpanded Optional param to force nav expand behavior when not null
- */
-function toggleMenu(nav, navSections, forceExpanded = null) {
-  const expanded = forceExpanded !== null ? !forceExpanded : nav.getAttribute('aria-expanded') === 'true';
-  const button = nav.querySelector('.nav-hamburger button');
-  document.body.style.overflowY = (expanded || isDesktop.matches) ? '' : 'hidden';
-  nav.setAttribute('aria-expanded', expanded ? 'false' : 'true');
-  toggleAllNavSections(navSections, expanded || isDesktop.matches ? 'false' : 'true');
-  button.setAttribute('aria-label', expanded ? 'Open navigation' : 'Close navigation');
-  // enable nav dropdown keyboard accessibility
-  const navDrops = navSections.querySelectorAll('.nav-drop');
-  if (isDesktop.matches) {
-    navDrops.forEach((drop) => {
-      if (!drop.hasAttribute('tabindex')) {
-        drop.setAttribute('tabindex', 0);
-        drop.addEventListener('focus', focusNavSection);
-      }
-    });
-  } else {
-    navDrops.forEach((drop) => {
-      drop.removeAttribute('tabindex');
-      drop.removeEventListener('focus', focusNavSection);
-    });
-  }
-
-  // enable menu collapse on escape keypress
-  if (!expanded || isDesktop.matches) {
-    // collapse menu on escape press
-    window.addEventListener('keydown', closeOnEscape);
-    // collapse menu on focus lost
-    nav.addEventListener('focusout', closeOnFocusLost);
-  } else {
-    window.removeEventListener('keydown', closeOnEscape);
-    nav.removeEventListener('focusout', closeOnFocusLost);
-  }
-}
-
-function decorateSubNav(navSection) {
-  const allSubNavLinks = navSection.querySelectorAll('a');
-  allSubNavLinks.forEach((link) => {
-    link.classList.add('link');
-    link.parentElement?.classList.add('button-container');
+function formatHeaderElements(fragments) {
+  fragments.forEach((section, i) => {
+    const innerSection = section.querySelector('.section');
+    if (!innerSection) return;
+    section.innerHTML = innerSection.innerHTML;
+    const areas = ['brand', 'quick-links', 'main', 'tools'];
+    section.classList.add(`nav-${areas[i]}`);
+    section.classList.remove('section-outer');
+    section.removeAttribute('data-section-status');
+    section.removeAttribute('style');
+    if (i === 0) {
+      const userIcon = createTag('img', { src: icons.user, alt: 'Login' });
+      const userBtn = createTag('a', { class: 'btn-mobile btn-user', href: 'https://customer.creditacceptance.com/login', target: '_blank' }, userIcon);
+      section.prepend(userBtn);
+      const hamAttr = {
+        class: 'btn-mobile btn-ham',
+        'aria-label': 'Open navigation',
+        'aria-controls': 'nav-main',
+        'aria-expanded': 'false',
+        type: 'button',
+      };
+      const hamIcon = createTag('div', { class: 'icon-ham' }, '<span></span><span></span><span></span><span></span>');
+      const hamBtn = createTag('button', hamAttr, hamIcon);
+      section.append(hamBtn);
+    } else {
+      section.classList.add('nav-section');
+      section.setAttribute('aria-expanded', 'false');
+    }
   });
+  decorateMainMenu(fragments[2]);
 }
 
-function loadSecondaryNavFragment(navChildFragmentLink, secondaryNav) {
-  const navChildFragmentPath = navChildFragmentLink.getAttribute('href');
-  loadFragment(navChildFragmentPath).then((fragment) => {
-    secondaryNav.append(fragment);
-    decorateSubNav(fragment);
+function decorateFragment(block, fragment) {
+  block.textContent = '';
+  const fragSections = [...fragment.children];
+  formatHeaderElements(fragSections);
+  const nav = createTag('nav', { id: 'nav' }, fragSections);
+  block.append(nav);
+
+  const hamburger = document.querySelector('.btn-ham');
+  const navSections = document.querySelectorAll('.nav-section');
+  hamburger.addEventListener('click', () => {
+    const isExpanded = hamburger.getAttribute('aria-expanded') === 'true';
+    hamburger.setAttribute('aria-expanded', !isExpanded);
+    navSections.forEach((s) => {
+      s.setAttribute('aria-expanded', !isExpanded);
+    });
   });
 }
 
@@ -128,100 +90,5 @@ export default async function decorate(block) {
   const navMeta = getMetadata('nav');
   const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/nav';
   const fragment = await loadFragment(navPath);
-
-  // decorate nav DOM
-  block.textContent = '';
-  const nav = document.createElement('nav');
-  nav.id = 'nav';
-  while (fragment.firstElementChild) nav.append(fragment.firstElementChild);
-
-  const classes = ['brand', 'sections', 'tools'];
-  classes.forEach((c, i) => {
-    const section = nav.children[i];
-    if (section) section.classList.add(`nav-${c}`);
-  });
-
-  const navBrand = nav.querySelector('.nav-brand');
-  const brandLink = navBrand.querySelector('.button');
-  if (brandLink) {
-    brandLink.className = '';
-    brandLink.closest('.button-container').className = '';
-  }
-
-  const navSections = nav.querySelector('.nav-sections');
-  if (navSections) {
-    navSections.querySelectorAll(':scope .default-content-wrapper > ul > li').forEach((navSection) => {
-      // wrap the content within the navSection in a span
-      const navSectionContent = navSection.innerHTML;
-      navSection.innerHTML = '';
-      const navSectionContentWrapper = document.createElement('span');
-      navSectionContentWrapper.innerHTML = navSectionContent;
-      navSection.append(navSectionContentWrapper);
-      if (navSection.querySelector('ul')) {
-        navSection.classList.add('nav-drop');
-        const secondaryNav = document.createElement('div');
-        secondaryNav.className = 'nav-secondary';
-        const navChildFragmentLink = navSection.querySelectorAll('a[href*="/fragment"]');
-        if (navChildFragmentLink.length > 1) {
-          if (isDesktop.matches) {
-            loadSecondaryNavFragment(navChildFragmentLink[0], secondaryNav);
-          } else {
-            loadSecondaryNavFragment(navChildFragmentLink[1], secondaryNav);
-          }
-          navChildFragmentLink[0].closest('ul').remove();
-        } else if (navChildFragmentLink.length) {
-          loadSecondaryNavFragment(navChildFragmentLink[0], secondaryNav);
-          navChildFragmentLink[0].closest('ul').remove();
-        }
-        navSection.append(secondaryNav);
-      }
-      if (navSection.querySelector('ul')) navSection.classList.add('nav-drop');
-
-      navSection.addEventListener('mouseenter', () => {
-        if (isDesktop.matches) {
-          toggleAllNavSections(navSections);
-          navSection.setAttribute('aria-expanded', 'true');
-        }
-      });
-
-      navSection.addEventListener('click', (e) => {
-        e.stopPropagation();
-      });
-
-      document.addEventListener('click', (e) => {
-        if (isDesktop.matches && !navSection.contains(e.target)) {
-          toggleAllNavSections(navSections);
-          navSection.setAttribute('aria-expanded', 'false');
-        }
-      });
-
-      navSections.querySelectorAll(':scope .default-content-wrapper > ul > li').forEach((otherNavSection) => {
-        if (otherNavSection !== navSection) {
-          otherNavSection.addEventListener('mouseenter', () => {
-            if (isDesktop.matches) {
-              navSection.setAttribute('aria-expanded', 'false');
-            }
-          });
-        }
-      });
-    });
-  }
-
-  // hamburger for mobile
-  const hamburger = document.createElement('div');
-  hamburger.classList.add('nav-hamburger');
-  hamburger.innerHTML = `<button type="button" aria-controls="nav" aria-label="Open navigation">
-      <span class="nav-hamburger-icon"></span>
-    </button>`;
-  hamburger.addEventListener('click', () => toggleMenu(nav, navSections));
-  nav.prepend(hamburger);
-  nav.setAttribute('aria-expanded', 'false');
-  // prevent mobile nav behavior on window resize
-  toggleMenu(nav, navSections, isDesktop.matches);
-  isDesktop.addEventListener('change', () => toggleMenu(nav, navSections, isDesktop.matches));
-
-  const navWrapper = document.createElement('div');
-  navWrapper.className = 'nav-wrapper';
-  navWrapper.append(nav);
-  block.append(navWrapper);
+  decorateFragment(block, fragment);
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -8,6 +8,29 @@ const icons = {
   user: 'https://main--creditacceptance--aemsites.aem.page/icons/user.svg',
 };
 
+function createRipple(event) {
+  const button = event.currentTarget;
+
+  const circle = document.createElement('span');
+  const buttonRect = button.getBoundingClientRect();
+  const diameter = Math.max(buttonRect.width, buttonRect.height);
+  const radius = diameter / 2;
+
+  // Calculate relative coordinates within the button
+  const relativeX = event.clientX - buttonRect.left;
+  const relativeY = event.clientY - buttonRect.top;
+
+  circle.style.width = `${diameter}px`;
+  circle.style.height = `${diameter}px`;
+  circle.style.left = `${relativeX - radius}px`;
+  circle.style.top = `${relativeY - radius}px`;
+  circle.classList.add('ripple');
+
+  const ripple = button.getElementsByClassName('ripple')[0];
+  if (ripple) ripple.remove();
+  button.prepend(circle);
+}
+
 function decorateMainMenu(section) {
   const navHeaders = section.querySelectorAll('h3');
   if (!navHeaders) return;
@@ -16,6 +39,7 @@ function decorateMainMenu(section) {
     const details = createTag('details', { class: `nav-detail detail-${i}` }, summaryTag);
     navHeader.replaceWith(details);
     const list = details.nextElementSibling;
+    const listLinks = list.querySelectorAll('li');
     if (!list) return;
     details.append(list);
 
@@ -27,6 +51,12 @@ function decorateMainMenu(section) {
       details.addEventListener('mouseout', () => {
         details.removeAttribute('open');
       });
+      summaryTag.addEventListener('mousedown', createRipple);
+      if (listLinks.length) {
+        listLinks.forEach((l) => {
+          l.addEventListener('mousedown', createRipple);
+        });
+      }
     }
   });
 }
@@ -41,10 +71,11 @@ function formatHeaderElements(fragments) {
     section.classList.remove('section-outer');
     section.removeAttribute('data-section-status');
     section.removeAttribute('style');
+    const contentWrapper = section.querySelector('.default-content-wrapper');
     if (i === 0) {
       const userIcon = createTag('img', { src: icons.user, alt: 'Login' });
       const userBtn = createTag('a', { class: 'btn-mobile btn-user', href: 'https://customer.creditacceptance.com/login', target: '_blank' }, userIcon);
-      section.prepend(userBtn);
+      contentWrapper.prepend(userBtn);
       const hamAttr = {
         class: 'btn-mobile btn-ham',
         'aria-label': 'Open navigation',
@@ -54,7 +85,7 @@ function formatHeaderElements(fragments) {
       };
       const hamIcon = createTag('div', { class: 'icon-ham' }, '<span></span><span></span><span></span><span></span>');
       const hamBtn = createTag('button', hamAttr, hamIcon);
-      section.append(hamBtn);
+      contentWrapper.append(hamBtn);
     } else {
       section.classList.add('nav-section');
       section.setAttribute('aria-expanded', 'false');

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -20,7 +20,6 @@ main > .section-outer > .section.tabs-container {
     position: relative;
     margin: 0;
     color: var(--tabs-active-text-color);
-    background-color: var(--tabs-active-bg-color);
     z-index: 1;
 }
 


### PR DESCRIPTION
I refactored the nav to use a [single file](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%7BAF3F3792-C5D1-401F-B467-A949F78964CF%7D&file=nav1.docx&action=default&mobileredirect=true) and adjusted the scripts and styles to accommodate all viewports.  

I have an [index.html doc](https://adobe.sharepoint.com/sites/HelixProjects/_layouts/15/doc.aspx?sourcedoc={7e9c0036-dc0d-43ee-8225-f28993ef1cf3}&action=edit) in my drafts directory with the metadata table pointing to this 'nav-new'. This will look wonky on other pages FYI

Fix [#50](https://github.com/aemsites/creditacceptance/issues/50)

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/rparrish/
- After: https://rparrish-menu--creditacceptance--aemsites.aem.page/drafts/rparrish/

Testing criteria - Check that the main nav looks just like the live site in both mobile and desktop views. 
Note: they're are some known slight variations below that will be discussed w/ the client. 
 - Links have default UI - underline on hover, colors
 - Mobile view - Logo remains in place rather then hiding when menu is open

Heads up: User Account icon on mobile - The url is hardcoded in the .js decorator. 
This isn't author able but it could be if needed ( or maybe use ref from quick-links) 

Bonus: added 'ripple' effect on desktop main nav and list items. 

Known caveats: There is no resize handler to toggle the eventListners for the dropdowns so they may auto expand on hover when scaling the viewport in testing. Refresh is required for accurate UI. I can add a resize event if needed. (this uses native html `detail & summary` tags for accordion etc.)