### PR TITLE
#23 - add card block variations

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -8,7 +8,7 @@
      padding: 0;
      display: grid;
      grid-template-columns: repeat(auto-fill, minmax(257px, 1fr));
-     gap: 32px;
+     gap: var(--gap-lg);
  }
 
  .cards>ul>li {
@@ -25,6 +25,7 @@
 
  .cards .cards-card-body p.date {
     font-size: 18px;
+    color: var(--tertiary-indigo);
     margin-block: 1rem;
  }
 
@@ -78,6 +79,27 @@
  .cards.rounded .cards-card-body {
      margin: 0;
  }
+
+ /* Gap Variant */
+.cards.gap-xs > ul {
+    gap: var(--gap-xs);
+  }
+  
+ .cards.gap-sm > ul {
+    gap: var(--gap-sm);
+  }
+  
+ .cards.gap-md > ul {
+    gap: var(--gap-md);
+  }
+  
+ .cards.gap-lg > ul {
+    gap: var(--gap-lg);
+  }
+  
+ .cards.gap-xl > ul {
+    gap: var(--gap-xl);
+  }
 
  /* Resources Variant */
  .cards.resources>ul {

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -1,116 +1,170 @@
- .cards > ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(257px, 1fr));
-  gap: 32px;
+ .cards {
+    margin-block-start: 24px;
+ }
+ 
+ .cards>ul {
+     list-style: none;
+     margin: 0;
+     padding: 0;
+     display: grid;
+     grid-template-columns: repeat(auto-fill, minmax(257px, 1fr));
+     gap: 32px;
+ }
+
+ .cards>ul>li {
+     background: var(--background-color);
+ }
+
+ .cards>ul>li>.card-wrapper {
+     padding: 1rem 1.5rem;
+ }
+
+ .cards .cards-card-body {
+     margin: 16px;
+ }
+
+ .cards .cards-card-body p.date {
+    font-size: 18px;
+    margin-block: 1rem;
+ }
+
+ .cards .cards-card-body .card-title {
+    margin-block-start: 1rem;
+ }
+
+ .cards .cards-card-body.ellipsed p {
+     display: -webkit-box;
+     max-height: 130px !important;
+     overflow: hidden;
+     text-overflow: ellipsis;
+     white-space: break-spaces;
+     line-clamp: 4;
+     -webkit-line-clamp: 4;
+     -webkit-box-orient: vertical;
+ }
+
+ .cards .cards-card-image {
+     line-height: 0;
+ }
+
+ .cards>ul>li img {
+     width: 100%;
+     aspect-ratio: 4 / 3;
+     object-fit: cover;
+ }
+
+ /* Ups Variant */
+@media (width >=960px) {
+    .cards.two-up > ul{
+        grid-template-columns: repeat(2, minmax(257px, 1fr));
+    }
+
+    .cards.three-up > ul {
+        grid-template-columns: repeat(3, minmax(257px, 1fr));
+    }
+
+    .cards.four-up > ul {
+        grid-template-columns: repeat(4, minmax(257px, 1fr));
+    }
 }
 
-.cards > ul > li {
-  background: var(--background-color);
-}
+ /* Rounded Variant */
+ .cards.rounded>ul>li>.card-wrapper {
+     border-radius: 11px;
+     box-shadow: 0 2px 6px #0000001f, 0 4px 25px #00000024;
+     transition: .3s transform cubic-bezier(.155, 1.105, .295, 1.12), .3s box-shadow;
+ }
 
-.cards .cards-card-body {
-  margin: 16px;
-}
+ .cards.rounded .cards-card-body {
+     margin: 0;
+ }
 
-.cards .cards-card-image {
-  line-height: 0;
-}
+ /* Resources Variant */
+ .cards.resources>ul {
+     display: flex;
+     flex-wrap: wrap;
+ }
 
-.cards > ul > li img {
-  width: 100%;
-  aspect-ratio: 4 / 3;
-  object-fit: cover;
-}
+ .cards.resources>ul>li {
+     width: 100%;
+     display: flex;
+     flex-direction: column;
+ }
 
-/* Resources Variant */
-.cards.resources > ul {
-  display: flex;
-  flex-wrap: wrap;
-}
+ .cards.resources>ul>li h3 {
+     padding: 48px 0;
+     font-size: 32px;
+ }
 
-.cards.resources > ul > li {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-}
+ .cards.resources>ul>li .card-wrapper {
+     padding: 1rem 1.5rem;
+     background: var(--very-light-gray);
+     box-shadow: 0 2px 6px #0000001f, 0 4px 25px #00000024;
+     transition: 0.3s transform cubic-bezier(.155, 1.105, .295, 1.12), 0.3s box-shadow;
+     flex-grow: 1;
+ }
 
-.cards.resources > ul > li h3 {
-  padding: 48px 0;
-  font-size: 32px;
-}
+ .cards.animation>ul>li .card-wrapper:hover {
+     box-shadow: 0 8px 54px #0003, 0 4px 8px #0000003b;
+ }
 
-.cards.resources > ul > li .card-wrapper {
-  padding: 1rem 1.5rem;
-  background: var(--very-light-gray);
-  box-shadow: 0 2px 6px #0000001f, 0 4px 25px #00000024;
-  transition: 0.3s transform cubic-bezier(.155, 1.105, .295, 1.12), 0.3s box-shadow;
-  flex-grow: 1;
-}
+ .cards.resources>ul>li .icon {
+     display: inline-block;
+     height: 100%;
+     width: auto;
+ }
 
-.cards.animation > ul > li .card-wrapper:hover {
-  box-shadow: 0 8px 54px #0003, 0 4px 8px #0000003b;
-}
+ .cards.resources .cards-card-body .icon-masked {
+     height: 80px;
+     width: 80px;
+     background: var(--credit-iconography-blue);
+ }
 
-.cards.resources > ul > li .icon {
-  display: inline-block;
-  height: 100%;
-  width: auto;
-}
+ .cards.resources>ul>li img {
+     aspect-ratio: 1 / 1;
+     object-fit: contain;
+ }
 
-.cards.resources .cards-card-body .icon-masked {
-  height: 80px;
-  width: 80px;
-  background: var(--credit-iconography-blue);
-}
+ .cards.resources .cards-card-body ol {
+     padding-left: 0;
+ }
 
-.cards.resources > ul > li img {
-  aspect-ratio: 1 / 1;
-  object-fit: contain;
-}
+ .cards.resources .cards-card-body ol li {
+     display: flex;
+     align-items: flex-start;
+     list-style: none;
+     counter-increment: item;
+     padding: 8px 0;
+ }
 
-.cards.resources .cards-card-body ol {
-  padding-left: 0;
-}
+ .cards.resources .cards-card-body ol li::before {
+     content: counter(item);
+     width: 30px;
+     height: 30px;
+     margin-right: 8px;
+     border-radius: 50%;
+     background: var(--credit-indigo);
+     color: var(--soft-white);
+     font-size: 14px;
+     line-height: 17px;
+     display: flex;
+     align-items: center;
+     justify-content: center;
+     flex-shrink: 0;
+ }
 
-.cards.resources .cards-card-body ol li {
-  display: flex;
-  align-items: flex-start;
-  list-style: none;
-  counter-increment: item;
-  padding: 8px 0;
-}
+ .cards.resources.center .cards-card-body h4,
+ .cards.resources.center .cards-card-body p:not(.button-container) {
+     text-align: left;
+ }
 
-.cards.resources .cards-card-body ol li::before { 
-  content: counter(item);
-  width: 30px;
-  height: 30px;
-  margin-right: 8px;
-  border-radius: 50%;
-  background: var(--credit-indigo);
-  color: var(--soft-white);
-  font-size: 14px;
-  line-height: 17px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
+ .cards.resources.center .cards-card-body .icon-masked {
+     margin: 0 auto;
+ }
 
-.cards.resources.center .cards-card-body h4,
-.cards.resources.center .cards-card-body p:not(.button-container) {
-  text-align: left;
-}
-
-.cards.resources.center .cards-card-body .icon-masked {
-  margin: 0 auto;
-}
-
-@media (width >= 960px) {
-  .cards.resources > ul > li {
-    flex: 1 1 calc(50% - 16px);
-    max-width: calc(50% - 16px);
-  }
-}
+ @media (width >=960px) {
+     .cards.resources>ul>li {
+         flex: 1 1 calc(50% - 16px);
+         max-width: calc(50% - 16px);
+     }
+ }

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -1,6 +1,25 @@
 import { createOptimizedPicture } from '../../scripts/aem.js';
 import { createTag } from '../../libs/utils/utils.js';
 
+function isDateValid(dateStr) {
+  if (!dateStr || typeof dateStr !== 'string') return false;
+
+  // eslint-disable-next-line no-restricted-globals
+  return !isNaN(new Date(dateStr));
+}
+
+function decorateDate(data) {
+  if (!data) return;
+
+  if (Array.from(data)) {
+    data.forEach((p) => {
+      if (isDateValid(p.textContent)) {
+        p.classList.add('date');
+      }
+    });
+  }
+}
+
 export default function decorate(block) {
   const isAnimated = block.classList.contains('animation');
   const ul = createTag('ul');
@@ -19,6 +38,17 @@ export default function decorate(block) {
         if (h3) {
           heading = h3;
           div.removeChild(h3);
+        }
+
+        const cardTitle = div.querySelector('h4, h5, h6');
+        cardTitle?.classList.add('card-title');
+
+        const paragraphs = div.querySelectorAll('p');
+        decorateDate(paragraphs);
+
+        const link = div.querySelector('a');
+        if (link) {
+          div.classList.add('ellipsed');
         }
       }
       const icon = div.querySelector('.icon img');

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -30,6 +30,7 @@
   --credit-iconography-blue: #40ABDE;
   --button-bg-blue: #c4eefa;
   --orange: #fa6400;
+  --tertiary-indigo: #3d5470;
 
   /* link text color */
   --link-text-color: hsl(193deg 82% 34%);
@@ -78,6 +79,13 @@
     
   /* containers */
   --container-width: 100%;
+
+  /* gaps */
+  --gap-xs: 12px;
+  --gap-sm: 16px;
+  --gap-md: 24px;
+  --gap-lg: 32px;
+  --gap-xl: 48px;
 }
 
 *, ::before, ::after {


### PR DESCRIPTION
This PR extends features to current `Card` block with `rounded`, `gap-{size}`, `{number}-ups`

Fix #23

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/smalla/cards
- After: https://smalla-cards--creditacceptance--aemsites.aem.page/drafts/smalla/cards