### PR TITLE
Revert ffetch.js

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -3,12 +3,12 @@
 import ffetch from '../../scripts/ffetch.js';
 
 let palettePromise;
-function fetchPalette(sheet) {
+function fetchPalette() {
   if (!palettePromise) {
     palettePromise = new Promise((resolve, reject) => {
       (async () => {
         try {
-          const paletteJson = await ffetch('/tools/taxonomy.json', sheet).all();
+          const paletteJson = await ffetch('/tools/taxonomy.json').sheet('palette').all();
           resolve(paletteJson);
         } catch (e) {
           reject(e);
@@ -20,7 +20,7 @@ function fetchPalette(sheet) {
 }
 
 export async function getPalette() {
-  return fetchPalette('palette');
+  return fetchPalette();
 }
 
 export async function loadPalette() {

--- a/scripts/ffetch.js
+++ b/scripts/ffetch.js
@@ -167,7 +167,7 @@ function assignOperations(generator, context) {
   return Object.assign(generator, operations, functions);
 }
 
-export default function ffetch(url, sheet) {
+export default function ffetch(url) {
   let chunks = 255;
   const fetch = (...rest) => window.fetch.apply(null, rest);
   const parseHtml = (html) => new window.DOMParser().parseFromString(html, 'text/html');
@@ -179,12 +179,7 @@ export default function ffetch(url, sheet) {
     }
   } catch (e) { /* ignore */ }
 
-  const context = {
-    chunks,
-    sheet,
-    fetch,
-    parseHtml,
-  };
+  const context = { chunks, fetch, parseHtml };
   const generator = request(url, context);
 
   return assignOperations(generator, context);

--- a/tools/tagger/tagger.js
+++ b/tools/tagger/tagger.js
@@ -8,12 +8,12 @@ function titleToName(name) {
 
 const taxonomyEndpoint = '/tools/taxonomy.json';
 let taxonomyPromise;
-function fetchTaxonomy(sheet) {
+function fetchTaxonomy() {
   if (!taxonomyPromise) {
     taxonomyPromise = new Promise((resolve, reject) => {
       (async () => {
         try {
-          const taxonomyJson = await ffetch(taxonomyEndpoint, sheet).all();
+          const taxonomyJson = await ffetch(taxonomyEndpoint).sheet('tags').all();
           const taxonomy = {};
           let curType;
           let l1;
@@ -67,7 +67,7 @@ const getDeepNestedObject = (obj, filter) => Object.entries(obj)
  * @returns {Promise} the taxonomy
  */
 export function getTaxonomy() {
-  return fetchTaxonomy('tags');
+  return fetchTaxonomy();
 }
 
 /**


### PR DESCRIPTION
Reverted the ffetch.js lib to original file and passed `sheet` param as [documented](https://github.com/adobe/ffetch)

Fix N/A

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/tools/tagger/index.html
- After: https://rparrish-fix-ffetch--creditacceptance--aemsites.aem.page/tools/tagger/index.html

Testing criteria - Have a look at the above URL's they should be the same. The after should still load the tagger and palette ffetch'd data