### PR TITLE
#111 - add related-cards block

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -18,6 +18,7 @@
  .cards>ul>li>.card-wrapper {
      padding: 1rem 1.5rem;
      overflow: hidden;
+     height: 100%;
  }
 
  .cards .cards-card-body {
@@ -35,7 +36,7 @@
     min-height: 35px;
  }
 
- .cards .cards-card-body.ellipsed p:first-of-type {
+ .cards .cards-card-body.ellipsed p:nth-of-type(2) {
      display: -webkit-box;
      max-height: 130px;
      overflow: hidden;

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -36,7 +36,9 @@
     min-height: 35px;
  }
 
- .cards .cards-card-body.ellipsed p:nth-of-type(2) {
+ .cards .cards-card-body.ellipsed p:nth-of-type(1),
+ .cards .cards-card-body.ellipsed.has-date p:nth-of-type(2),
+ .cards .cards-card-body.ellipsed p.card-description {
      display: -webkit-box;
      max-height: 130px;
      overflow: hidden;

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -15,6 +15,7 @@ function decorateDate(data) {
     data.forEach((p) => {
       if (isDateValid(p.textContent)) {
         p.classList.add('date');
+        p.closest('.cards-card-body')?.classList.add('has-date');
       }
     });
   }

--- a/blocks/related-cards/related-cards.css
+++ b/blocks/related-cards/related-cards.css
@@ -1,0 +1,1 @@
+/* stylelint-disable no-empty-source */

--- a/blocks/related-cards/related-cards.js
+++ b/blocks/related-cards/related-cards.js
@@ -1,0 +1,66 @@
+import {
+  buildBlock, createOptimizedPicture, decorateIcons, getMetadata, loadBlock,
+} from '../../scripts/aem.js';
+import { createTag } from '../../libs/utils/utils.js';
+import { decorateButtons } from '../../libs/utils/decorate.js';
+
+export default async function init(block) {
+  const links = block.querySelectorAll('a');
+  const cardBlock = [];
+
+  const promises = Array.from(links).map(async (link, index) => {
+    const { href } = link;
+    if (!href) return;
+
+    const url = new URL(href).pathname;
+    const response = await fetch(url);
+    if (!response.ok) return;
+
+    const html = await response.text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+
+    const title = getMetadata('og:title', doc);
+    const description = getMetadata('og:description', doc);
+    const image = getMetadata('mobileimage', doc) || getMetadata('og:image', doc);
+    const imageAlt = getMetadata('og:image:alt', doc) || title;
+
+    const imageElement = createOptimizedPicture(image, imageAlt);
+
+    const firstCol = createTag('div', null, [imageElement]);
+    const heading = createTag('h4', { class: 'card-title' }, [title]);
+    const descriptionElement = createTag('p', { class: 'card-description' }, description);
+
+    const linkElement = createTag('a', { href }, 'Read >');
+    const secondaryLink = createTag('em', { class: 'button-container' }, linkElement);
+    const linkWrapper = createTag('p', null, secondaryLink);
+
+    const secondCol = createTag('div', null, [heading, descriptionElement, linkWrapper]);
+
+    const date = getMetadata('date', doc);
+    if (date) {
+      const formattedDate = new Date(date).toLocaleDateString('en-GB', {
+        day: '2-digit',
+        month: 'short',
+        year: '2-digit',
+        timeZone: 'UTC',
+      }).replace(',', '');
+      const dateElement = createTag('p', { class: 'card-date' }, formattedDate);
+      secondCol.prepend(dateElement);
+    }
+
+    cardBlock[index] = [firstCol, secondCol];
+  });
+
+  await Promise.all(promises);
+
+  const card = buildBlock('cards', cardBlock);
+  card.dataset.blockName = 'cards';
+  decorateButtons(card);
+  decorateIcons(card);
+
+  card.classList.add('rounded', 'block', 'animation', 'three-up');
+  const loadedCard = await loadBlock(card);
+  block.innerHTML = loadedCard.innerHTML;
+  block.classList.add(...loadedCard.classList);
+}


### PR DESCRIPTION
This allows authors to use urls to create related cards.

Fix #111 

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/smalla/related-cards
- After: https://smalla-related-cards--creditacceptance--aemsites.aem.page/drafts/smalla/related-cards

Testing criteria - Compare against related cards in https://www.creditacceptance.com/ 