### PR TITLE
#146 Menu Updates

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -151,8 +151,13 @@ header .nav-brand {
   text-transform: uppercase;
   letter-spacing: 0.7px;
   line-height: 20px;
-  a{
-    color: var(--primary-black);
+
+  a {
+    color: var(--credit-indigo);
+
+    &:hover {
+        color: var(--primary-black);
+    }
   }
 }
 
@@ -286,7 +291,7 @@ header .nav-brand {
   header .nav-main .default-content-wrapper,
   header .nav-tools .default-content-wrapper {
     display: flex;
-    gap: 1rem;
+    gap: 1.5rem;
     height: 100%;
     align-content: center;
   }

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -25,6 +25,15 @@ header {
       position: relative;
     }
     
+    details > summary {
+        list-style: none;
+    }
+        
+    details > summary::marker,
+    details > summary::-webkit-details-marker {
+        display: none;
+    }
+    
 }
 
 /* brand */
@@ -377,7 +386,7 @@ header .nav-brand {
     
     details[open] > summary::before {
       content: "\2304";
-    }  
+    }
   }
   
   /* nav tools */

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -136,14 +136,24 @@ header .nav-brand {
   .icon { height: 100%; }
 }
 
+.nav-brand[data-nav-expanded="true"] {
+    .btn-user, 
+    .btn-brand {
+        visibility: hidden;
+    }
+}
+
 .nav-main,
 .nav-tools {
-  color: var(--black-olive);
+  color: var(--primary-black);
   font-size: 12px;
   font-family: var(--ff-acceptance-demi-bold);
   text-transform: uppercase;
   letter-spacing: 0.7px;
   line-height: 20px;
+  a{
+    color: var(--primary-black);
+  }
 }
 
 .nav-main {

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -7,6 +7,7 @@ const isDesktop = window.matchMedia('(min-width: 960px)');
 const icons = {
   user: 'https://main--creditacceptance--aemsites.aem.page/icons/user.svg',
 };
+const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
 
 function createRipple(event) {
   const button = event.currentTarget;
@@ -44,7 +45,7 @@ function decorateMainMenu(section) {
     details.append(list);
 
     /* toggle on mouseover in desktop */
-    if (isDesktop.matches) {
+    if (isDesktop.matches && !isTouchDevice) {
       details.addEventListener('mouseover', () => {
         details.setAttribute('open', '');
       });
@@ -117,14 +118,23 @@ function decorateFragment(block, fragment) {
   });
 }
 
-// toggle mobile menu if clicked outside of nav
+/* Handle click outside of nav on mobile and detail on desktop */
 document.addEventListener('click', (event) => {
   if (!isDesktop.matches) {
     const mainNav = document.querySelector('#nav');
+    // toggle mobile menu if clicked outside of nav
     if (mainNav && !mainNav.contains(event.target)) {
       const hamburger = document.querySelector('.btn-ham');
       if (hamburger.getAttribute('aria-expanded') === 'true') hamburger.click();
     }
+  } else {
+    const details = document.querySelectorAll('#nav details');
+    details.forEach((detail) => {
+      // toggle main menu detail if clicked outside
+      if (detail && !detail.contains(event.target)) {
+        if (detail.hasAttribute('open')) detail.removeAttribute('open');
+      }
+    });
   }
 });
 

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -123,7 +123,7 @@ document.addEventListener('click', (event) => {
     const mainNav = document.querySelector('#nav');
     if (mainNav && !mainNav.contains(event.target)) {
       const hamburger = document.querySelector('.btn-ham');
-      hamburger.click();
+      if (hamburger.getAttribute('aria-expanded') === 'true') hamburger.click();
     }
   }
 });

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -83,6 +83,9 @@ function formatHeaderElements(fragments) {
         'aria-expanded': 'false',
         type: 'button',
       };
+      const brandLink = section.querySelector('.icon-CA_Logo');
+      if (brandLink) brandLink.parentNode.classList.add('btn-brand');
+      section.setAttribute('data-nav-expanded', 'false');
       const hamIcon = createTag('div', { class: 'icon-ham' }, '<span></span><span></span><span></span><span></span>');
       const hamBtn = createTag('button', hamAttr, hamIcon);
       contentWrapper.append(hamBtn);
@@ -102,9 +105,11 @@ function decorateFragment(block, fragment) {
   block.append(nav);
 
   const hamburger = document.querySelector('.btn-ham');
+  const navBrand = document.querySelector('.nav-brand');
   const navSections = document.querySelectorAll('.nav-section');
   hamburger.addEventListener('click', () => {
     const isExpanded = hamburger.getAttribute('aria-expanded') === 'true';
+    navBrand.setAttribute('data-nav-expanded', !isExpanded);
     hamburger.setAttribute('aria-expanded', !isExpanded);
     navSections.forEach((s) => {
       s.setAttribute('aria-expanded', !isExpanded);

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -117,6 +117,33 @@ function decorateFragment(block, fragment) {
   });
 }
 
+// toggle mobile menu if clicked outside of nav
+document.addEventListener('click', (event) => {
+  if (!isDesktop.matches) {
+    const mainNav = document.querySelector('#nav');
+    if (mainNav && !mainNav.contains(event.target)) {
+      const hamburger = document.querySelector('.btn-ham');
+      hamburger.click();
+    }
+  }
+});
+
+function toggleView() {
+  const navBrand = document.querySelector('.nav-brand');
+  if (isDesktop.matches) {
+    navBrand.setAttribute('data-nav-expanded', 'false');
+  } else {
+    const hamburger = document.querySelector('.btn-ham');
+    const isExpanded = hamburger.getAttribute('aria-expanded') === 'true';
+    navBrand.setAttribute('data-nav-expanded', isExpanded);
+  }
+}
+
+// Call toggleView on resize
+window.addEventListener('resize', () => {
+  toggleView();
+});
+
 /**
  * loads and decorates the header, mainly the nav
  * @param {Element} block The header block element

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -34,20 +34,20 @@
   --tertiary-indigo: #3d5470;
 
   /* link text color */
-  --link-text-color: hsl(193deg 82% 34%);
-  --link-text-color-hover: hsl(193deg 82% 20%);
-  --link-text-color-visited: hsl(193deg 82% 20%);
-  --link-text-color-light: hsl(193deg 82% 65%);
-  --link-text-color-light-hover: hsl(193deg 82% 75%);
-  --link-text-color-light-visited: hsl(193deg 82% 75%);
+  --link-text-color: oklch(62% 0.09 264deg);
+  --link-text-color-hover: oklch(52% 0.09 264deg);
+  --link-text-color-visited: oklch(52% 0.09 264deg);
+  --link-text-color-light: oklch(82% 0.09 264deg);
+  --link-text-color-light-hover: oklch(92% 0.09 264deg);
+  --link-text-color-light-visited: oklch(92% 0.09 264deg);
 
   /* buttons */
-  --btn-primary-bg: hsl(43deg 100% 50%);
-  --btn-primary-bg-hover: hsl(43deg 100% 41%);
-  --btn-primary-blue-bg: hsl(193deg 84% 87%);
-  --btn-primary-blue-bg-hover: hsl(193deg 84% 80%);
-  --btn-secondary-border: #2b4361;
-  --btn-secondary-border-hover: #0A293B;
+  --btn-primary-bg: oklch(83% 0.17 81.97deg / 100%);
+  --btn-primary-bg-hover: oklch(73% 0.14 81.97deg);
+  --btn-primary-blue-bg: oklch(91% 0.11 233.5deg);
+  --btn-primary-blue-bg-hover: oklch(84% 0.11 233.5deg);
+  --btn-secondary-border: oklch(38% 0.06 254.57deg / 100%);
+  --btn-secondary-border-hover: oklch(27% 0.05 238.22deg / 100%);
 
   /* fonts */
   --body-font-family: 'Visibly Regular', visby-regular-fallback, sans-serif;
@@ -391,7 +391,7 @@ a.button.secondary:focus,
 button.secondary:focus,
 a.button.secondary:hover,
 button.secondary:hover {
-  box-shadow: 0 0 0 1px var(--btn-secondary-border-hover); /* Simulate border increase */
+  box-shadow: inset 0 0 0 1px var(--btn-secondary-border-hover); /* Simulate border increase */
   color: var(--btn-secondary-border-hover);
 }
 


### PR DESCRIPTION
The following has been addressed in the main menu

1. Remove default ::marker arrows on menu details element on IOS (see below)
2. Increase spacing/gap on nav about-us, careers items
3. Adjust nav links color to match site
4. On the mobile menu, when the nav is open, the account icon and logo shouldn't display
5. Clicking outside the nav on mobile and desktop view should close/collapse its respective nav list

Fix [#146](https://github.com/aemsites/creditacceptance/issues/146)

**Test URLs:**
- Before: https://main--creditacceptance--aemsites.aem.page/
- After: https://rparrish-menu-update--creditacceptance--aemsites.aem.page/

**Testing criteria**
Test the above list is remedied

Bonus - updated our style.css link/button colors from `hsl` to `oklch` and fixed the secondary hover style to inset to there's no hidden overflow 