### PR TITLE
[#145] Card: Resources, images left aligned fix

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -145,6 +145,8 @@
      height: 80px;
      width: 80px;
      background: var(--credit-iconography-blue);
+     mask-position: left;
+     mask-repeat: no-repeat;
  }
 
  .cards.resources>ul>li img {
@@ -187,6 +189,7 @@
 
  .cards.resources.center .cards-card-body .icon-masked {
      margin: 0 auto;
+     mask-position: center;
  }
 
  @media (width >=960px) {

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -54,13 +54,8 @@ export default function decorate(block) {
       }
       const icon = div.querySelector('.icon img');
       if (icon) {
-        const maskedDiv = createTag('div', { class: 'icon-masked', style: `mask:url(${icon.src}) no-repeat center` });
+        const maskedDiv = createTag('div', { class: 'icon-masked', style: `mask-image :url(${icon.src})` });
         icon.parentNode.parentNode.replaceWith(maskedDiv);
-        const img = new Image();
-        img.src = icon.src;
-        img.onload = () => {
-          maskedDiv.style.width = `${img.width}px`;
-        };
       }
     });
     if (heading) li.append(heading);

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -56,6 +56,13 @@ export default function decorate(block) {
       if (icon) {
         const maskedDiv = createTag('div', { class: 'icon-masked', style: `mask:url(${icon.src}) no-repeat center` });
         icon.parentNode.parentNode.replaceWith(maskedDiv);
+
+        const img = new Image();
+        img.src = icon.src
+
+        img.onload = () => {
+          maskedDiv.style.width = `${img.width}px`;
+        };
       }
     });
     if (heading) li.append(heading);

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -56,10 +56,8 @@ export default function decorate(block) {
       if (icon) {
         const maskedDiv = createTag('div', { class: 'icon-masked', style: `mask:url(${icon.src}) no-repeat center` });
         icon.parentNode.parentNode.replaceWith(maskedDiv);
-
         const img = new Image();
-        img.src = icon.src
-
+        img.src = icon.src;
         img.onload = () => {
           maskedDiv.style.width = `${img.width}px`;
         };


### PR DESCRIPTION
Fix for icons on the resource cards not being left aligned. 

Fix #145 

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/car-buyers/express-lane/5-ways-to-build-or-reestablish-your-credit-history
- After: https://nrego-card-icons--creditacceptance--aemsites.aem.page/car-buyers/express-lane/5-ways-to-build-or-reestablish-your-credit-history

When the resource card is set to be left aligned, the icons should line up with the content on the left hand side. 