### PR TITLE
#88 Mobile slider for testimonials and new [image-text-overlay] block. 

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -59,6 +59,22 @@
      object-fit: cover;
  }
 
+/* mobile-only */
+@media screen and (width <= 959px) {
+    .cards > ul {
+        &.slider-container {
+            display: flex;
+            gap: 0;
+            padding: 0 2rem 3rem;
+
+            > li > .card-wrapper {
+                margin: 1rem;
+            }
+        }
+    }
+   
+}
+
  /* Ups Variant */
 @media (width >=960px) {
     .cards.two-up > ul{

--- a/blocks/image-text-overlay/image-text-overlay.css
+++ b/blocks/image-text-overlay/image-text-overlay.css
@@ -1,0 +1,83 @@
+@import url('../slider/slider.css');
+
+main > .section-outer > .section.image-text-overlay-container {
+  max-width: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+.image-text-overlay {
+  .image {
+    margin-block-end: 1rem;
+
+    picture {
+      height: 100%;
+    }
+    
+    img {
+      object-fit: cover;
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  .button-container {
+    text-align: center;
+  }
+}
+  
+  /* mobile-only */
+  @media screen and (width <= 959px) {
+    .card {
+      padding: 1rem;
+      margin: 1rem;
+      border-radius: 11px;
+      box-shadow: 0 2px 6px #0000001f, 0 4px 25px #00000024;
+      transition: .3s transform cubic-bezier(.155, 1.105, .295, 1.12), .3s box-shadow;
+  
+      &:hover {
+        box-shadow: 0 8px 54px #0003, 0 4px 8px #0000003b;
+        transform: scale(1.05);
+      }
+    }
+  }
+  
+  /* desktop up */
+@media screen and (width >= 960px) {
+  .image-text-overlay {
+    display: flex;
+    gap: 1rem;
+  }
+
+  .card {
+    height: 100%;
+    display: flex;
+    align-items: end;
+    position: relative;
+    flex-grow: 1;
+
+    .image {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      overflow: hidden;
+      
+      p,
+      picture {
+        height: 100%;
+        margin: 0;
+      }
+    }
+
+    .copy {
+      background-color: white;
+      padding: 1rem;
+      z-index: 0;
+      max-width: 400px;
+      margin: 12rem auto 0;
+    }
+  }
+}
+
+ 

--- a/blocks/image-text-overlay/image-text-overlay.css
+++ b/blocks/image-text-overlay/image-text-overlay.css
@@ -1,5 +1,3 @@
-@import url('../slider/slider.css');
-
 main > .section-outer > .section.image-text-overlay-container {
   max-width: 100%;
   padding: 0;

--- a/blocks/image-text-overlay/image-text-overlay.js
+++ b/blocks/image-text-overlay/image-text-overlay.js
@@ -1,0 +1,28 @@
+import { handleFocalpoint, initSlider } from '../../libs/utils/decorate.js';
+
+const isDesktop = window.matchMedia('(min-width: 960px)');
+
+function decorateCard(block, card) {
+  const cols = card.querySelectorAll(':scope > div');
+  const foreground = cols[cols.length - 1];
+  const background = cols.length > 1 ? cols[0] : null;
+  if (background) {
+    background.classList.add('image');
+    block.classList.add('has-bg');
+    const bgPic = background.querySelector('picture');
+    const focalPoint = background.querySelector('p + p');
+    if (focalPoint) handleFocalpoint(bgPic, focalPoint, true);
+  }
+  foreground.classList.add('copy');
+}
+
+export default function decorate(block) {
+  const rows = block.querySelectorAll(':scope > div');
+  rows.forEach((card, i) => {
+    card.classList.add(`card-${i}`, 'card');
+    decorateCard(block, card);
+  });
+  if (block.classList.contains('slider-mobile') && !isDesktop.matches) {
+    initSlider(block, rows);
+  }
+}

--- a/blocks/image-text-overlay/image-text-overlay.js
+++ b/blocks/image-text-overlay/image-text-overlay.js
@@ -1,4 +1,5 @@
 import { handleFocalpoint, initSlider } from '../../libs/utils/decorate.js';
+import { loadCSS } from '../../scripts/aem.js';
 
 const isDesktop = window.matchMedia('(min-width: 960px)');
 
@@ -23,6 +24,7 @@ export default function decorate(block) {
     decorateCard(block, card);
   });
   if (block.classList.contains('slider-mobile') && !isDesktop.matches) {
+    loadCSS(`${window.hlx.codeBasePath}/blocks/slider/slider.css`);
     initSlider(block, rows);
   }
 }

--- a/blocks/slider/slider.css
+++ b/blocks/slider/slider.css
@@ -1,0 +1,68 @@
+ 
+.slider-wrapper {
+  position: relative;
+}
+
+/* slider mobile-only */
+ @media screen and (width <= 959px) {
+  .slider-container {
+    width: 100Vw;
+    overflow: visible;
+    display: flex;
+    overflow-x: scroll;
+    scroll-snap-type: x mandatory;
+    scroll-behavior: smooth;
+    -webkit-overflow-scrolling: touch;
+    padding: 2rem;
+
+    &::-webkit-scrollbar {
+      width: 0;
+      height: 0;
+    }
+  
+    &::-webkit-scrollbar-thumb {
+      background: transparent;
+    }
+  
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .slide {
+      scroll-snap-align: center;
+      flex-shrink: 0;
+      width: 80%;
+    }
+  }
+
+  .pagination {
+    position: absolute;
+    bottom: -1rem;
+    padding-bottom: 1rem;
+    left: 0;
+    width: 100vw;
+    background: white;
+    display: flex;
+    justify-content: center;
+    gap: .5rem;
+
+    button.dot {
+      background: #e8e7df;
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      border: none;
+      
+      &.active {
+        background-color: #87cf25;
+      }
+    }
+  }
+}
+
+/* slider desktop up */
+@media screen and (width >= 960px) {
+  .pagination {
+    display: none;
+  }
+}

--- a/blocks/testimonials/testimonials.css
+++ b/blocks/testimonials/testimonials.css
@@ -1,5 +1,3 @@
-@import url('../slider/slider.css');
-
 .testimonials .card-image-person img {
     height: 110px;
     object-fit: contain;

--- a/blocks/testimonials/testimonials.css
+++ b/blocks/testimonials/testimonials.css
@@ -1,3 +1,5 @@
+@import url('../slider/slider.css');
+
 .testimonials .card-image-person img {
     height: 110px;
     object-fit: contain;
@@ -32,4 +34,13 @@
     line-clamp: 4;
     -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
+}
+
+/* mobile-only */
+@media screen and (width <= 959px) {
+    main > .section-outer > .section.testimonials-container:has(.slider-wrapper) {
+        max-width: 100%;
+        padding: 0;
+        margin: 0;
+    }
 }

--- a/blocks/testimonials/testimonials.js
+++ b/blocks/testimonials/testimonials.js
@@ -1,6 +1,10 @@
 import ffetch from '../../scripts/ffetch.js';
 import {
-  buildBlock, createOptimizedPicture, decorateIcons, loadBlock,
+  buildBlock,
+  createOptimizedPicture,
+  decorateIcons,
+  loadBlock,
+  loadCSS,
 } from '../../scripts/aem.js';
 import { createTag } from '../../libs/utils/utils.js';
 import { decorateButtons, initSlider } from '../../libs/utils/decorate.js';
@@ -96,6 +100,7 @@ async function decorateCards(block, { reviews, url }) {
   if (isSlider && !isDesktop.matches) {
     const sliderContainer = block.querySelector('ul');
     const slides = sliderContainer.querySelectorAll(':scope > li');
+    loadCSS(`${window.hlx.codeBasePath}/blocks/slider/slider.css`);
     initSlider(block, slides, sliderContainer);
   }
 }

--- a/blocks/testimonials/testimonials.js
+++ b/blocks/testimonials/testimonials.js
@@ -3,7 +3,9 @@ import {
   buildBlock, createOptimizedPicture, decorateIcons, loadBlock,
 } from '../../scripts/aem.js';
 import { createTag } from '../../libs/utils/utils.js';
-import { decorateButtons } from '../../libs/utils/decorate.js';
+import { decorateButtons, initSlider } from '../../libs/utils/decorate.js';
+
+const isDesktop = window.matchMedia('(min-width: 960px)');
 
 function getKeyValuePairs(block) {
   const { children } = block;
@@ -89,6 +91,13 @@ async function decorateCards(block, { reviews, url }) {
 
   block.classList.add(...card.classList);
   block.innerHTML = loadedCard.innerHTML;
+
+  const isSlider = block.classList.contains('slider-mobile');
+  if (isSlider && !isDesktop.matches) {
+    const sliderContainer = block.querySelector('ul');
+    const slides = sliderContainer.querySelectorAll(':scope > li');
+    initSlider(block, slides, sliderContainer);
+  }
 }
 
 export default async function init(block) {

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -1,5 +1,7 @@
 // Shared block decorate functions
 
+import { createTag } from './utils.js';
+
 /**
  * Checks if a hex color value is dark or light
  *
@@ -130,4 +132,49 @@ export function decorateGridSection(section, meta) {
     const spanVal = gridValues[i].trim();
     if (spanVal) row.classList.add(spanVal);
   });
+}
+
+function updateActiveSlide(steps, pagination) {
+  const dots = pagination.querySelectorAll('button');
+  function handleIntersection(entries) {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        const visibleStep = entry.target;
+        const index = Array.from(steps).indexOf(visibleStep);
+        dots.forEach((dot) => dot.classList.remove('active'));
+        dots[index].classList.add('active');
+      }
+    });
+  }
+  // Create observer with 50% visibility threshold
+  const observer = new IntersectionObserver(handleIntersection, { threshold: 0.5 });
+  steps.forEach((step) => observer.observe(step)); // Start observing each step
+}
+
+export function initSlider(block, slides, container = null) {
+  if (!slides) return;
+  const slideContainer = container || block;
+  slideContainer.classList.add('slider-container');
+  const pagination = createTag('div', { class: 'pagination' }, null);
+  slides.forEach((slide, i) => {
+    slide.id = `slide-${i}`;
+    slide.classList.add('slide');
+    const dot = createTag('button', { type: 'button', class: `dot dot-slide-${i}` });
+    pagination.append(dot);
+
+    // scroll into view on click
+    slide.addEventListener('click', () => {
+      slide.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    });
+
+    dot.addEventListener('click', (event) => {
+      event.preventDefault();
+      slide.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    });
+  });
+  const { blockName } = block.dataset;
+  const outerSection = block.closest(`.${blockName}-wrapper`);
+  outerSection.classList.add('slider-wrapper');
+  outerSection.append(pagination);
+  updateActiveSlide(slides, pagination);
 }


### PR DESCRIPTION
- Added 🆕  [image-text-overlay] block 
- Added a shared initSlider() function in `decorate.js` and supporting `slider.css` styles
- Added 'slider-mobile' variant options on [image-text-overlay] and [testimonials] blocks

![image](https://github.com/user-attachments/assets/fcf8ca3b-cf43-4b60-a67d-aff7ec663a48)


Fix [#88](https://github.com/aemsites/creditacceptance/issues/88)

Test URLs:
- Before: http://main--creditacceptance--aemsites.aem.page/drafts/rparrish/card-sliders
- After: https://rparrish-img-txt-overlay--creditacceptance--aemsites.aem.page/drafts/rparrish/card-sliders

Testing criteria 
Check the test url in both mobile and desktop to make sure the UI and look match the [live site HP](https://www.creditacceptance.com/) usage. (refresh is needed for slider to init.)
This pattern is going to be used on many of the [campaign](https://www.creditacceptance.com/campaign/200-promo) pages