### PR TITLE
[#193, #194] Carousel slides per view on mobile and arrow placement

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -1,6 +1,6 @@
 .carousel {
   position: relative;
-  padding: 12px 0;
+  margin: 12px 0;
 }
 
 .carousel .carousel-slides-container {
@@ -45,9 +45,8 @@
   justify-content: center;
   align-items: center;
   height: 100%;
-  width: calc(100% - 24px);
+  width: calc(100% - 12px);
   flex-direction: column;
-  max-height: 220px;
 }
 
 .carousel.carousel.aspect-ratio-rectangle .carousel-slide-image {
@@ -64,9 +63,6 @@
   object-fit: cover;
   margin: 0 auto;
   display: flex;
-}
-
-.carousel.aspect-ratio-square .carousel-slide .carousel-slide-image picture > img {
   aspect-ratio: 1 / 1;
 }
 
@@ -108,8 +104,8 @@
 }
 
 .carousel .carousel-navigation-buttons button {
-  width: 44px;
-  height: 44px;
+  width: 30px;
+  height: 34px;
   border: none;
   background: none;
 }
@@ -126,29 +122,49 @@
 
 .carousel .carousel-navigation-buttons {
   position: absolute;
-  top: 50%;
   left: 0;
   right: 0;
-  transform: translateY(-50%);
   display: flex;
   align-items: center;
   justify-content: space-between;
   z-index: 1;
 }
 
+.carousel[data-slides-per-view="2"] .carousel-slide {
+  flex: 0 0 50%; 
+  width: 50%; 
+}
+
+.carousel[data-slides-per-view="3"] .carousel-slide { 
+  flex: 0 0 33.33%; 
+  width: 33.33%; 
+}
+
+.carousel[data-slides-per-view="4"] .carousel-slide { 
+  flex: 0 0 25%;
+  width: 25%; 
+}
+
+.carousel[data-slides-per-view="5"] .carousel-slide { 
+  flex: 0 0 20%;
+  width: 20%; 
+}
+
+.carousel[data-arrows="false"] .carousel-navigation-buttons {
+  display: none;
+}
+
+.carousel-slide-image p {
+  margin: 0;
+}
+
 @media (width >= 960px) {
-  .carousel.slides-per-view-2 .carousel-slide { 
-    flex: 0 0 50%; 
-    width: 50%; 
+  .carousel-slide-image {
+    width: calc(100% - 24px);
   }
 
-  .carousel.slides-per-view-3 .carousel-slide { 
-    flex: 0 0 33.33%; 
-    width: 33.33%; 
-  }
-  
-  .carousel.slides-per-view-4 .carousel-slide { 
-    flex: 0 0 25%;
-    width: 25%; 
+  .carousel-slide-image img {
+    max-height: 220px;
   }
 }
+  


### PR DESCRIPTION
Update for carousel block: 
- Slides per view can be set for desktop or mobile 
- Arrows hidden if total slide length is equal to or slides per view
- Arrow placement (center with image) 

Fix #193 #194 

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/nrego/carousel
- After: https://nrego-carousel-update--creditacceptance--aemsites.aem.page/drafts/nrego/carousel