### PR TITLE
#107 - Table-sum

### DIFF
--- a/blocks/table-sum-metadata/table-sum-metadata.css
+++ b/blocks/table-sum-metadata/table-sum-metadata.css
@@ -1,0 +1,1 @@
+/* Table sum metadata */

--- a/blocks/table-sum-metadata/table-sum-metadata.js
+++ b/blocks/table-sum-metadata/table-sum-metadata.js
@@ -1,0 +1,3 @@
+const init = () => {};
+
+export default init;

--- a/blocks/table-sum/table-sum.css
+++ b/blocks/table-sum/table-sum.css
@@ -1,0 +1,75 @@
+.table-sum {
+    /* var --columns-count is set dynamically */
+    text-align: center;
+}
+
+.table-sum .upper,
+.table-sum .lower {
+    display: grid;
+    grid-template-columns: repeat(var(--columns-count), 1fr);
+}
+
+.table-sum .upper {
+    gap: 10px;
+    padding: 10px;
+    margin-block: 0 12px;
+}
+
+.table-sum .column {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+}
+
+.table-sum .cell {
+    min-height: 50px;
+    width: 100%;
+}
+
+.table-sum .upper .cell {
+    height: 50px;
+    border-bottom: 1px dotted #D9D9D9;
+}
+
+.table-sum .upper .cell:not(.header) {
+    padding: 10px;
+}
+
+.table-sum .upper .cell.empty,
+.table-sum .upper .cell.header,
+.table-sum .upper .cell:last-child {
+    border: none;
+}
+
+.table-sum .separator {
+    border-top: 2px dotted var(--credit-indigo);
+    width: calc(4 * 100% / var(--columns-count));
+    margin-inline-start: calc(3 * 100% / var(--columns-count));
+    margin-block: 10px;
+}
+
+.table-sum .upper .column .cell:last-child {
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
+}
+
+.table-sum .upper .column .cell:not(.header) {
+    background-color: #f5f5f7; 
+}
+
+.table-sum .upper .column:nth-child(1) .cell:not(.empty) {
+    background-color: transparent;
+}
+
+.table-sum .upper .column:nth-child(2) .cell:not(.empty),
+.table-sum .upper .column:nth-child(3) .cell:not(.empty) {
+    background-color: #abb5bf;
+}
+
+.table-sum .upper .column .cell.header + .cell,
+.table-sum .upper .column .cell:first-child:not(.header) {
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+}

--- a/blocks/table-sum/table-sum.css
+++ b/blocks/table-sum/table-sum.css
@@ -1,12 +1,15 @@
 .table-sum {
-    /* var --columns-count is set dynamically */
+    /* var --columns-desktop-count is set dynamically */
+    --table-sum-dark-grey: #abb5bf;
+    --table-sum-light-grey: #f5f5f7;
+
     text-align: center;
 }
 
 .table-sum .upper,
 .table-sum .lower {
     display: grid;
-    grid-template-columns: repeat(var(--columns-count), 1fr);
+    grid-template-columns: repeat(var(--columns-mobile-count), auto);
 }
 
 .table-sum .upper {
@@ -44,10 +47,7 @@
 }
 
 .table-sum .separator {
-    border-top: 2px dotted var(--credit-indigo);
-    width: calc(4 * 100% / var(--columns-count));
-    margin-inline-start: calc(3 * 100% / var(--columns-count));
-    margin-block: 10px;
+    display: none;
 }
 
 .table-sum .upper .column .cell:last-child {
@@ -56,20 +56,89 @@
 }
 
 .table-sum .upper .column .cell:not(.header) {
-    background-color: #f5f5f7; 
+    background-color: var(--column-color);
 }
 
-.table-sum .upper .column:nth-child(1) .cell:not(.empty) {
-    background-color: transparent;
-}
-
-.table-sum .upper .column:nth-child(2) .cell:not(.empty),
-.table-sum .upper .column:nth-child(3) .cell:not(.empty) {
-    background-color: #abb5bf;
-}
-
-.table-sum .upper .column .cell.header + .cell,
+.table-sum .upper .column .cell.header+.cell,
 .table-sum .upper .column .cell:first-child:not(.header) {
     border-top-left-radius: 5px;
     border-top-right-radius: 5px;
+}
+
+.table-sum .column.hide-mobile,
+.table-sum .column.slider-mobile {
+    display: none;
+}
+
+.table-sum .column.hide-desktop {
+    display: flex;
+}
+
+.table-sum .lower .column:has(.cell.empty) {
+    display: none;
+}
+
+.table-sum .lower {
+    display: flex;
+    gap: 40px;
+}
+
+.table-sum .swiper {
+    display: flex;
+    gap: 20px;
+    overflow: auto;
+    scroll-snap-type: x mandatory;
+    -ms-overflow-style: none;  /* IE and Edge */
+    scrollbar-width: none;  /* Firefox */
+    &::-webkit-scrollbar {
+        display: none; /* Hide scrollbar for Chrome, Safari and Opera */
+    }
+}
+
+
+/* stylelint-disable-next-line no-descending-specificity */
+.table-sum .swiper .swiper-slide .cell {
+    width: calc(100vw - 70vw);
+    scroll-snap-align: start;
+}
+
+@media screen and (width>=992px) {
+    .table-sum .upper,
+    .table-sum .lower {
+        display: grid;
+        grid-template-columns: repeat(var(--columns-desktop-count), 1fr);
+    }
+
+    .table-sum .lower {
+        display: grid;
+        gap: 0;
+    }
+
+    .table-sum .lower .column:has(.cell.empty) {
+        display: block;
+    }
+
+    .table-sum .upper .column.hide-desktop,
+    .table-sum .lower .column.hide-desktop,
+    .table-sum .lower .column.hide-desktop:has(.cell.empty) {
+        display: none;
+    }
+
+
+    .table-sum .column.hide-mobile,
+    .table-sum .column.slider-mobile {
+        display: block;
+    }
+
+    .table-sum .separator {
+        display: block;
+        border-top: 2px dotted var(--credit-indigo);
+        width: calc(var(--columns-slider-count) * 100% / var(--columns-desktop-count));
+        margin-inline-start: calc((var(--columns-desktop-count) - var(--columns-slider-count)) * 100% / var(--columns-desktop-count));
+        margin-block: 10px;
+    }
+
+    .table-sum .swiper {
+        display: none;
+    }
 }

--- a/blocks/table-sum/table-sum.css
+++ b/blocks/table-sum/table-sum.css
@@ -133,9 +133,7 @@
     .table-sum .separator {
         display: block;
         border-top: 2px dotted var(--credit-indigo);
-        width: calc(var(--columns-slider-count) * 100% / var(--columns-desktop-count));
-        margin-inline-start: calc((var(--columns-desktop-count) - var(--columns-slider-count)) * 100% / var(--columns-desktop-count));
-        margin-block: 10px;
+         margin-block: 10px;
     }
 
     .table-sum .swiper {

--- a/blocks/table-sum/table-sum.js
+++ b/blocks/table-sum/table-sum.js
@@ -1,0 +1,40 @@
+import { createTag } from '../../libs/utils/utils.js';
+
+export default function init(block) {
+  const columns = [];
+  const rows = block.querySelectorAll(':scope > div');
+
+  // creates 2D array as columns containing row's cells
+  Array.from(rows).forEach((row, i) => {
+    const cells = row.querySelectorAll(':scope > div');
+    Array.from(cells).forEach((cell, j) => {
+      if (!columns[j]) columns[j] = [];
+      columns[j][i] = cell.textContent;
+    });
+  });
+
+  const upper = createTag('div', { class: 'upper' });
+  const lower = createTag('div', { class: 'lower' });
+  const separator = createTag('div', { class: 'separator' });
+
+  columns.forEach((column) => {
+    const col = createTag('div', { class: 'column' });
+    column.forEach((cell, j) => {
+      const cellEl = createTag('div', { class: j === 0 ? 'cell header' : 'cell' }, cell);
+      if (!cellEl.textContent) {
+        cellEl.classList.add('empty');
+      }
+      if (j === columns.length - 1) {
+        lower.append(cellEl);
+      } else {
+        col.append(cellEl);
+      }
+    });
+    upper.append(col);
+  });
+
+  block.innerHTML = '';
+  block.append(upper, separator, lower);
+
+  block.style.setProperty('--columns-count', columns.length);
+}

--- a/blocks/table-sum/table-sum.js
+++ b/blocks/table-sum/table-sum.js
@@ -24,6 +24,35 @@ function getBlockMetadata(block) {
   return data;
 }
 
+function decorateSeparator(lower) {
+  const columns = lower.querySelectorAll('.column');
+  let start = 0;
+  let end = columns.length - 1;
+  for (let i = 0; i < columns.length; i += 1) {
+    if (columns[i].textContent.trim()) {
+      start = i;
+      break;
+    }
+  }
+
+  for (let i = columns.length - 1; i >= 0; i -= 1) {
+    if (columns[i].textContent.trim()) {
+      end = i;
+      break;
+    }
+  }
+
+  const separator = createTag('div', { class: 'separator' });
+
+  const lowerStyles = getComputedStyle(lower, '--columns-desktop-count');
+  const desktopColumnCount = lowerStyles.getPropertyValue('--columns-desktop-count');
+
+  const width = ((end - start + 1) / parseInt(desktopColumnCount, 10)) * 100;
+  separator.style.width = `${width}%`;
+  separator.style.marginInlineStart = `calc(100% - ${width}%)`;
+  lower.insertAdjacentElement('beforebegin', separator);
+}
+
 export default function init(block) {
   const columns = [];
   const rows = block.querySelectorAll(':scope > div');
@@ -39,7 +68,7 @@ export default function init(block) {
 
   const upper = createTag('div', { class: 'upper' });
   const lower = createTag('div', { class: 'lower' });
-  const separator = createTag('div', { class: 'separator' });
+  // const separator = createTag('div', { class: 'separator' });
 
   columns.forEach((column) => {
     const upperCol = createTag('div', { class: 'column' });
@@ -70,7 +99,7 @@ export default function init(block) {
   });
 
   block.innerHTML = '';
-  block.append(upper, separator, lower);
+  block.append(upper, lower);
 
   const metadata = getBlockMetadata(block);
 
@@ -98,7 +127,7 @@ export default function init(block) {
             const lowerColumn = block.querySelector(`.lower .column:nth-child(${columnIndex})`);
             lowerColumn.classList.add('hide-desktop');
           }
-          break
+          break;
         default:
           break;
       }
@@ -109,14 +138,19 @@ export default function init(block) {
   const columnsSliderCount = sliderColumns.length;
   block.style.setProperty('--columns-slider-count', columnsSliderCount);
 
-  const mobileColumnCount = block.querySelectorAll('.upper .column:not(.hide-mobile)').length - (sliderColumns.length - 1);
+  const mobileColumns = block.querySelectorAll('.upper .column:not(.hide-mobile)');
+  const mobileColumnCount = columnsSliderCount ? mobileColumns.length - (sliderColumns.length - 1)
+    : mobileColumns.length;
   block.style.setProperty('--columns-mobile-count', mobileColumnCount);
 
   const desktopColumnCount = block.querySelectorAll('.upper .column:not(.hide-desktop)').length;
   block.style.setProperty('--columns-desktop-count', desktopColumnCount);
 
+  decorateSeparator(lower);
+
+  if (!columnsSliderCount) return;
   const swiper = createTag('div', { class: 'swiper' });
-  Array.from(sliderColumns).forEach((column, i) => {
+  Array.from(sliderColumns).forEach((column) => {
     const clone = column.cloneNode(true);
     clone.classList.remove('slider-mobile');
     clone.classList.add('swiper-slide');

--- a/blocks/table-sum/table-sum.js
+++ b/blocks/table-sum/table-sum.js
@@ -12,6 +12,7 @@ function getBlockMetadata(block) {
     const valueCol = row.children[1].textContent.trim().toLowerCase();
     const keys = keyCol.split(',');
     keys.forEach((key) => {
+      // eslint-disable-next-line no-unused-vars
       const [_, index, type] = key.split('-');
       data.push({
         columnIndex: parseInt(index, 10),

--- a/blocks/table-sum/table-sum.js
+++ b/blocks/table-sum/table-sum.js
@@ -1,5 +1,29 @@
 import { createTag } from '../../libs/utils/utils.js';
 
+function getBlockMetadata(block) {
+  const section = block.closest('.section-outer');
+  const metadata = section.querySelector('.table-sum-metadata');
+  metadata.style.display = 'none';
+
+  const rows = metadata.querySelectorAll(':scope > div');
+  const data = [];
+  Array.from(rows).forEach((row) => {
+    const keyCol = row.children[0].textContent.trim().toLowerCase();
+    const valueCol = row.children[1].textContent.trim().toLowerCase();
+    const keys = keyCol.split(',');
+    keys.forEach((key) => {
+      const [_, index, type] = key.split('-');
+      data.push({
+        columnIndex: parseInt(index, 10),
+        type,
+        value: valueCol,
+      });
+    });
+  });
+
+  return data;
+}
+
 export default function init(block) {
   const columns = [];
   const rows = block.querySelectorAll(':scope > div');
@@ -18,23 +42,85 @@ export default function init(block) {
   const separator = createTag('div', { class: 'separator' });
 
   columns.forEach((column) => {
-    const col = createTag('div', { class: 'column' });
+    const upperCol = createTag('div', { class: 'column' });
+    const lowerCol = createTag('div', { class: 'column' });
     column.forEach((cell, j) => {
-      const cellEl = createTag('div', { class: j === 0 ? 'cell header' : 'cell' }, cell);
+      const cellEl = createTag('div', { class: 'cell' }, cell);
+      if (j === 0) {
+        cellEl.classList.add('header');
+        if (cellEl.textContent.includes('{') && cellEl.textContent.includes('}')) {
+          const color = cellEl.textContent.match(/\{(.*?)\}/)[1];
+          cellEl.textContent = cellEl.textContent.replace(/\{(.*?)\}/, '');
+          upperCol.style.setProperty('--column-color', color.startsWith('#') ? color : `var(--${color})`);
+        }
+      }
+
       if (!cellEl.textContent) {
         cellEl.classList.add('empty');
       }
-      if (j === columns.length - 1) {
-        lower.append(cellEl);
+
+      if (j === column.length - 1) {
+        lowerCol.append(cellEl);
+        lower.append(lowerCol);
       } else {
-        col.append(cellEl);
+        upperCol.append(cellEl);
+        upper.append(upperCol);
       }
     });
-    upper.append(col);
   });
 
   block.innerHTML = '';
   block.append(upper, separator, lower);
 
-  block.style.setProperty('--columns-count', columns.length);
+  const metadata = getBlockMetadata(block);
+
+  metadata.forEach((meta) => {
+    const { columnIndex, type, value } = meta;
+    const decoratingColumns = block.querySelectorAll(`.upper .column:nth-child(${columnIndex})`);
+    decoratingColumns.forEach((column) => {
+      switch (type) {
+        case 'color':
+          column.style.setProperty('--column-color', value.startsWith('#') ? value : `var(--${value})`);
+          break;
+        case 'mobile':
+          // value could be either 'hide' or 'slider'
+          if (value === 'hide') {
+            column.classList.add('hide-mobile');
+          }
+          if (value === 'slider') {
+            column.classList.add('slider-mobile');
+          }
+          break;
+
+        case 'desktop':
+          if (value === 'hide') {
+            column.classList.add('hide-desktop');
+            const lowerColumn = block.querySelector(`.lower .column:nth-child(${columnIndex})`);
+            lowerColumn.classList.add('hide-desktop');
+          }
+          break
+        default:
+          break;
+      }
+    });
+  });
+
+  const sliderColumns = block.querySelectorAll('.upper .column.slider-mobile');
+  const columnsSliderCount = sliderColumns.length;
+  block.style.setProperty('--columns-slider-count', columnsSliderCount);
+
+  const mobileColumnCount = block.querySelectorAll('.upper .column:not(.hide-mobile)').length - (sliderColumns.length - 1);
+  block.style.setProperty('--columns-mobile-count', mobileColumnCount);
+
+  const desktopColumnCount = block.querySelectorAll('.upper .column:not(.hide-desktop)').length;
+  block.style.setProperty('--columns-desktop-count', desktopColumnCount);
+
+  const swiper = createTag('div', { class: 'swiper' });
+  Array.from(sliderColumns).forEach((column, i) => {
+    const clone = column.cloneNode(true);
+    clone.classList.remove('slider-mobile');
+    clone.classList.add('swiper-slide');
+    swiper.append(clone);
+  });
+  upper.append(swiper);
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -54,6 +54,7 @@
 
   /* borders */
   --bs-border-color: #dee2e6;
+  --bs-border-color-dotted: #D9D9D9;
 
   /* fonts */
   --body-font-family: 'Visby Regular', visby-regular-fallback, sans-serif;


### PR DESCRIPTION
This PR adds `table-sum` which can be configured with its corresponding metadata called `table-sum-metadata` similar to `tabs` block. The configuration details is provided in the test page.

Fix #107

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/smalla/table-sum
- After: https://smalla-table-sum--creditacceptance--aemsites.aem.page/drafts/smalla/table-sum

Testing criteria - Table found in https://www.creditacceptance.com/dealers/portfolio-program/details-50