### PR TITLE
#197 - fix background image causing CLS issue

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -505,8 +505,9 @@ function decorateSections(main) {
         } else if (key === 'background') {
           const urlIsImg = isImagePath(meta[key]);
           if (urlIsImg) {
-            const style = `background-image: url(${meta[key]}); background-repeat: no-repeat; background-size: cover;`;
-            sectionOuter.style = style;
+            sectionOuter.style.backgroundImage = `url(${meta[key]})`;
+            sectionOuter.style.backgroundRepeat = 'no-repeat';
+            sectionOuter.style.backgroundSize = 'cover';
           } else {
             let colorStr = meta[key];
             const isBrandColor = meta[key].startsWith('ca-');


### PR DESCRIPTION
The issue was that background image was overriding `display:none` with `background-image` causing the section to be visible before other section. This will append the background-image to the styles to fix CLS issue. 

Fix #197

Test URLs:
- Before: https://main--creditacceptance--aemsites.hlx.page/campaign/prequalify
- After: https://smalla-fix-cls-background-image--creditacceptance--aemsites.hlx.page/campaign/prequalify

Testing criteria - Run CLS score test