### PR TITLE
#219 - Different Picture with breakpoints (Careers Page)

### DIFF
--- a/blocks/picture/picture.css
+++ b/blocks/picture/picture.css
@@ -1,0 +1,61 @@
+.picture {
+    padding-inline: 12px;
+    margin-block: 30px;
+    margin-inline: 1rem;
+}
+
+.picture img {
+    width: 100%;
+    object-fit: cover;
+    object-position: center;
+}
+
+.picture .image-tablet, 
+.picture .image-desktop {
+    display: none;
+}
+
+@media screen and (width >= 576px) {
+    .picture {
+        margin-inline: 0;
+    }
+
+    .picture .image-mobile {
+        display: none;
+    } 
+
+    .picture .image-tablet {
+        display: block;
+    }
+}
+
+
+@media screen and (width >= 960px) {
+    .picture .image-tablet {
+        display: none;
+    }
+
+    .picture .image-desktop {
+        display: block;
+    }
+}
+
+/* specific for the careers page - picture & columns combination */
+.section.width-100 > .picture-wrapper + .columns-wrapper > .columns {
+    display: flex;
+    justify-content: center;
+    padding-inline: 12px;
+    margin-inline: 1rem;
+}
+
+@media screen and (width >= 576px) {
+    .section.width-100 > .picture-wrapper + .columns-wrapper > .columns {
+        justify-content: start;
+    } 
+}
+
+@media screen and (width >= 960px) {
+    .section.width-100 > .picture-wrapper + .columns-wrapper > .columns {
+        margin-inline: 0;
+    } 
+}

--- a/blocks/picture/picture.css
+++ b/blocks/picture/picture.css
@@ -43,19 +43,14 @@
 /* specific for the careers page - picture & columns combination */
 .section.width-100 > .picture-wrapper + .columns-wrapper > .columns {
     display: flex;
-    justify-content: center;
+    justify-content: start;
     padding-inline: 12px;
     margin-inline: 1rem;
-}
-
-@media screen and (width >= 576px) {
-    .section.width-100 > .picture-wrapper + .columns-wrapper > .columns {
-        justify-content: start;
-    } 
 }
 
 @media screen and (width >= 960px) {
     .section.width-100 > .picture-wrapper + .columns-wrapper > .columns {
         margin-inline: 0;
+        justify-content: center;
     } 
 }

--- a/blocks/picture/picture.js
+++ b/blocks/picture/picture.js
@@ -1,0 +1,16 @@
+export default function init(block) {
+  const { children } = block;
+
+  Array.from(children).forEach((row, index) => {
+    row.classList.add('picture-row');
+    row.dataset.pictureRow = index;
+    const columns = row.children;
+    const mobilePicture = columns[0]?.querySelector('picture');
+    const tabletPicture = columns[1]?.querySelector('picture');
+
+    const desktopPicture = columns[2]?.querySelector('picture');
+    mobilePicture?.classList.add('image-mobile');
+    tabletPicture?.classList.add('image-tablet');
+    desktopPicture?.classList.add('image-desktop');
+  });
+}


### PR DESCRIPTION
This adds `picture` block for easy authoring to include different picture for different screen sizes. 
This block also pairs with `columns` - when `columns` block is placed next to `picture` block this centers `columns` block in desktop when that section is full bleed.

Fix #219

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/smalla/picture
- After: https://smalla-picture-breakpoints--creditacceptance--aemsites.aem.page/drafts/smalla/picture

Testing criteria - Support & Training section at the bottom of the page https://www.creditacceptance.com/careers/hr