### PR TITLE
#283 - add columns (calculation) variant

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -262,6 +262,28 @@
     }
 }
 
+.columns.calculation > div {
+    font-family: var(--ff-acceptance-regular);
+    row-gap: 0.5rem;
+}
+
+.columns.calculation > div > div{
+    display: flex;
+    flex-flow: row;
+    gap: 0.5rem 1rem;
+}
+
+.columns.calculation .second-group {
+    display: flex;
+    justify-content: center;
+}
+
+.columns.calculation .separator {
+    width: 100%;
+    border-top: 2px solid var(--pure-black);
+} 
+
+
 /* mobile-tablet only */
 @media screen and (width <= 959px) {
     .columns.media-hidden-mobile .media-count-1 {
@@ -350,5 +372,19 @@
     &::before {
       top: -58px;
     }
+  }
+
+  .columns.calculation > div {
+    justify-content: center;
+  }
+
+  .columns.columns.calculation > div > div {
+    flex: 0 1 auto;
+    gap: 1.5rem;
+
+  }
+
+  .columns.calculation .separator {
+    display: none;
   }
 }

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -1,3 +1,5 @@
+import { createTag } from '../../libs/utils/utils.js';
+
 function decorateFlexRows(block) {
   const rows = block.querySelectorAll(':scope > div');
   const colClass = [...block.classList].find((cls) => cls.startsWith('col-'));
@@ -58,6 +60,17 @@ function isIconsCol(col) {
   }
 }
 
+function decorateColumnsCalculation(block) {
+  const rows = [...block.children];
+  rows.forEach((row) => {
+    const cols = [...row.children];
+    const separator = createTag('div', { class: 'separator' });
+    const firstGroup = createTag('div', { class: 'first-group' }, [cols[0], cols[1], cols[2]]);
+    const secondGroup = createTag('div', { class: 'second-group' }, [cols[3], cols[4]]);
+    row.append(firstGroup, separator, secondGroup);
+  });
+}
+
 export default function decorate(block) {
   const rows = [...block.children];
   // setup media columns
@@ -85,4 +98,6 @@ export default function decorate(block) {
   // flex basis
   decorateFlexRows(block);
   if (block.classList.contains('media-unbound')) applyMediaHeight(block);
+
+  if (block.classList.contains('calculation')) decorateColumnsCalculation(block);
 }


### PR DESCRIPTION
This piece of content is very different in mobile that cannot be solved with columns or any other block. So, adding a variant to `column` block called `calculation` to support this.
<img width="893" alt="Screenshot 2025-02-24 at 2 27 50 PM" src="https://github.com/user-attachments/assets/5d10e3ca-908d-45e4-88f2-d1bd9381b1a6" />

Fix #283

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/feb-19/campaign/grow-your-dealership/sp
- After: https://smalla-columns-calculation--creditacceptance--aemsites.aem.page/drafts/feb-19/campaign/grow-your-dealership/sp

Testing criteria - https://www.creditacceptance.com/campaign/grow-your-dealership