### PR TITLE
[#51] Logo only header - hide additional items on mobile

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -17,6 +17,7 @@ header {
       z-index: 2;
       position: relative;
       background-color: var(--light-gray);
+      height: var(--header-height);
     }
     p { margin: 0; }
 

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -284,12 +284,18 @@ header .nav-brand {
   }
 }
 
+/* nav variant with logo */
+.header.logo-only .btn-mobile.btn-user,
+.header.logo-only .btn-mobile.btn-ham {
+  display: none;
+}
+
 @media (width >= 960px) {
   /* brand */
   header nav {
     flex-direction: row;
     height: var(--nav-height);
-    padding-top: 0;
+    padding-top: 0.25rem;
     padding-bottom: 0;
   }
 

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -166,4 +166,8 @@ export default async function decorate(block) {
   const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/nav';
   const fragment = await loadFragment(navPath);
   decorateFragment(block, fragment);
+
+  if (block.querySelector('.nav-quick-links.nav-section').childNodes.length === 0) {
+    block.classList.add('logo-only');
+  }
 }


### PR DESCRIPTION
Hiding header elements on mobile for alternative nav with just logo present. 

Fix #51 

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/campaign/200-promo-rewards
- After: https://nrego-simple-header--creditacceptance--aemsites.aem.page/campaign/200-promo-rewards

Testing criteria - should match behaviour of current site: https://www.creditacceptance.com/campaign/200-promo-rewards