### PR TITLE
Grid section-metadata broken in library view

### DIFF
--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -48,7 +48,7 @@ export default async function decorate(block) {
   if (fragment) {
     const fragmentSection = fragment.querySelector(':scope .section');
     if (fragmentSection) {
-      block.closest('.section').classList.add(...fragmentSection.classList);
+      block.closest('.section')?.classList.add(...fragmentSection.classList);
       block.closest('.fragment').replaceWith(...fragment.childNodes);
     }
   }

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -123,15 +123,28 @@ export async function decorateBlockBg(block, node, { useHandleFocalpoint = false
   }
 }
 
+/**
+ * Decorates a section element with grid classes based on metadata.
+ *
+ * @param {HTMLElement} section - The section element to be decorated.
+ * @param {string} meta - A comma-separated string of class names to
+ * be applied to the section's rows.
+ */
 export function decorateGridSection(section, meta) {
-  const sectionRows = section.querySelectorAll('.section > div');
-  const gridValues = meta.split(',');
   section.classList.add('grid-section');
-  const gridRows = [...sectionRows].slice(0, -1); // remove last row .section-metadata
-  gridRows.forEach((row, i) => {
-    const spanVal = gridValues[i].trim();
-    if (spanVal) row.classList.add(spanVal);
-  });
+  const gridValues = meta.split(',').map((val) => val.trim().toLowerCase());
+
+  Array.from(section.querySelectorAll('.section > div'))
+    .filter((row) => {
+      const firstCol = row.querySelector(':scope > div');
+      if (firstCol.classList.contains('library-metadata')) row.classList.add('span-12');
+      return !firstCol?.classList.contains('section-metadata') && !firstCol?.classList.contains('library-metadata');
+    })
+    .forEach((row, i) => {
+      if (gridValues[i]) {
+        row.classList.add(gridValues[i]);
+      }
+    });
 }
 
 export function decorateGridSectionGroups(section, meta) {

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -137,7 +137,7 @@ export function decorateGridSection(section, meta) {
   Array.from(section.querySelectorAll('.section > div'))
     .filter((row) => {
       const firstCol = row.querySelector(':scope > div');
-      if (firstCol.classList.contains('library-metadata')) row.classList.add('span-12');
+      if (firstCol && firstCol.classList.contains('library-metadata')) row.classList.add('span-12');
       return !firstCol?.classList.contains('section-metadata') && !firstCol?.classList.contains('library-metadata');
     })
     .forEach((row, i) => {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -421,6 +421,10 @@ main > .section:first-of-type {
   margin-top: 0;
 }
 
+main > .section-outer {
+  overflow: hidden;
+}
+
 main > .section-outer > .section,
 footer .section-outer > .section,
 main.error .section-outer .section:not(.marquee-container),
@@ -552,6 +556,7 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
   .span-9 { grid-column: span 9; }
   .span-10 { grid-column: span 10; }
   .span-11 { grid-column: span 11; }
+  .span-12 { grid-column: span 12; }
 
   /* helpers */
   &.grid-justify-items-center {


### PR DESCRIPTION
Refactored the grid sections to address library usage
 - Also included a fix to address section-outer overflow: hidden for horizontal scroll when media-unbound is added. 
 
Fix /na

Libs URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/tools/sidekick/blocks/section
- After: https://rparrish-grid-library--creditacceptance--aemsites.aem.page/tools/sidekick/blocks/section

Grid Draft URLs: ⚠️ Regression testing ⚠️ 
- Before:https://main--creditacceptance--aemsites.aem.page/drafts/rparrish/grid-stats
- After: https://rparrish-grid-library--creditacceptance--aemsites.aem.page/drafts/rparrish/grid-stats

Testing criteria - Check that the library page loads on my branch and the respective grid sections look as advertised. (Aka the section in Libs url w/ a gray background)

