### PR TITLE
[#302] Modal shouldn't scroll to top on open

### DIFF
--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -9,7 +9,6 @@ body.modal-open {
 .modal dialog {
   overscroll-behavior: none;
   overflow-y: hidden;
-  position: relative;
   width: calc(100vw - 48px);
   max-width: 900px;
   max-height: calc(100dvh - (2 * var(--header-height)));


### PR DESCRIPTION
Fix #302

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/car-buyers/resources
- After: https://nrego-modal-scroll--creditacceptance--aemsites.aem.page/car-buyers/resources

Testing criteria - the user should not be scrolled to the top of the page when a modal is opened