### PR TITLE
Minor fixes - mobile header bg, default-content wrapper margin auto

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -17,7 +17,7 @@ header {
       z-index: 2;
       position: relative;
       background-color: var(--light-gray);
-      height: var(--header-height);
+      min-height: var(--header-height);
     }
     p { margin: 0; }
 

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -7,7 +7,7 @@ header {
   --menu-accent-orange: #ffb800;
 
     background-color: var(--light-gray);
-    height: var(--header-height);
+    min-height: var(--header-height);
     
     nav {
       padding: 0.5rem 1rem;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -7,7 +7,7 @@ header {
   --menu-accent-orange: #ffb800;
 
     background-color: var(--light-gray);
-    min-height: var(--header-height);
+    height: var(--header-height);
     
     nav {
       padding: 0.5rem 1rem;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -617,6 +617,7 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
     max-width: var(--container-width);
     padding-left: 0;
     padding-right: 0;
+    margin: 0 auto;
   }
 
   :root {  --container-width: 540px; }


### PR DESCRIPTION
- Fixed default content wrapper to be centered on tablet viewport
- Addressed header issue on expanded mobile (background white color wasn't flowing thru content) 

Fix [#233](https://github.com/aemsites/creditacceptance/issues/233)

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/customers
- After: https://rparrish-fixes--creditacceptance--aemsites.aem.page/customers

Testing criteria 
 - Open the pages above before/after and make sure the section `download the credit acceptance mobile app` is centered and not on the edge of the page on a tablet viewport `<578 && >968`
 - Size your browser to below desktop `>968` and toggle the menu hamburger. The white should show behind nav content on after view