### PR TITLE
Nrego/bugs mobile tablet

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -296,6 +296,22 @@
     .columns.media-hidden-mobile .media-count-1 {
         display: none;
     }
+
+    .columns.big-icons .copy {
+      display: grid;
+      grid-template-columns: 24px 1fr;
+      grid-template-rows: auto auto;
+      gap: 0 32px;
+    }
+  
+    .columns.big-icons .copy > p:first-of-type {
+      grid-row: span 2;
+      align-self: center;
+    }
+  
+    .columns.big-icons .copy > p:not(:first-of-type) {
+      margin-top: 0;
+    }
 }
 
 @media screen and (width < 576px) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -665,21 +665,3 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
 @media screen and (width >= 1400px) {
     :root { --container-width: 1320px; }
 }
-
-@media screen and (width < 960px) {
-  .columns.big-icons .copy {
-    display: grid;
-    grid-template-columns: 24px 1fr;
-    grid-template-rows: auto auto;
-    gap: 0 32px;
-  }
-
-  .columns.big-icons .copy > p:first-of-type {
-    grid-row: span 2;
-    align-self: center;
-  }
-
-  .columns.big-icons .copy > p:not(:first-of-type) {
-    margin-top: 0;
-  }
-}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -101,6 +101,7 @@ body {
   font-size: var(--body-font-size-m);
   line-height: 1.6;
   margin: 0;
+  overflow-x: hidden;
 }
 
 body.appear {
@@ -195,6 +196,7 @@ p {
   line-height: 1.5;
   margin-top: 0.75em;
   margin-bottom: 0.75em;
+  overflow-wrap: break-word;
 }
 
 .center {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -246,6 +246,7 @@ h1, h2, h3, h4, h5, h6, p {
 .big-icons .icon {
   width: auto;
   height: auto;
+  min-width: 25px;
 }
 
 /* Lists */
@@ -663,4 +664,22 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
 
 @media screen and (width >= 1400px) {
     :root { --container-width: 1320px; }
+}
+
+@media screen and (width < 960px) {
+  .columns.big-icons .copy {
+    display: grid;
+    grid-template-columns: 24px 1fr;
+    grid-template-rows: auto auto;
+    gap: 0 32px;
+  }
+
+  .columns.big-icons .copy > p:first-of-type {
+    grid-row: span 2;
+    align-self: center;
+  }
+
+  .columns.big-icons .copy > p:not(:first-of-type) {
+    margin-top: 0;
+  }
 }


### PR DESCRIPTION
Issues addressed: 
- User should not be able to drag page left/right on mobile 
- Text should not flow outside the page, but instead wrap 
- big-icons in column block should have a different layout on mobile 
- icons not appearing on mobile 

Fix #278, #276 

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/careers
- After: https://nrego-bugs-mobile-tablet--creditacceptance--aemsites.aem.page/careers

Testing criteria - what replicate the live site: https://www.creditacceptance.com/careers

For discussion: 
- Icon color changes on mobile 
- Icon alignment in other columns block on this page: do we need additional class to indicate col has icons and should be targeted on mobile?