### PR TITLE
#325 - Image Text Overlay - option to hide image on mobile

### DIFF
--- a/blocks/image-text-overlay/image-text-overlay.css
+++ b/blocks/image-text-overlay/image-text-overlay.css
@@ -38,6 +38,14 @@ main > .section-outer > .section.image-text-overlay-container {
         transform: scale(1.05);
       }
     }
+    
+    .image-text-overlay.image-hide-mobile {
+        min-height: 546px;
+    }
+
+    .image-text-overlay.image-hide-mobile .image > p{
+        display: none;
+    }
   }
   
   /* desktop up */
@@ -48,7 +56,6 @@ main > .section-outer > .section.image-text-overlay-container {
   }
 
   .card {
-    height: 100%;
     display: flex;
     align-items: end;
     position: relative;


### PR DESCRIPTION
This adds a optional class `image-hide-mobile` to hide decorating background image on mobile for `image-text-overlay` block.

Fix #325

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/campaign/grow-your-dealership#its-a-great-deal-only-if-it-benefits-you-and-your-customer
- After: https://smalla-image-text-overlay--creditacceptance--aemsites.aem.page/campaign/grow-your-dealership#its-a-great-deal-only-if-it-benefits-you-and-your-customer

Testing criteria - https://www.creditacceptance.com/campaign/grow-your-dealership