### PR TITLE
added overflow-visible to section styles

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -440,6 +440,10 @@ main > .section-outer {
   overflow: hidden;
 }
 
+main > .section-outer:has(.overflow-visible) {
+  overflow: visible;
+}
+
 main > .section-outer > .section,
 footer .section-outer > .section,
 main.error .section-outer .section:not(.marquee-container),


### PR DESCRIPTION
Added a style for section-metadata to opt in to `overflow: visible;`

Fix [#330](https://github.com/aemsites/creditacceptance/issues/330)

Test URLs:
- Before: https://main--creditacceptance--aemsites.hlx.page/campaign/prequalify
- After: https://rparrish-section-steps--creditacceptance--aemsites.hlx.page/campaign/prequalify

Testing criteria - make sure the steps (big numbers) in the section below the marquee are visible and over the marquee area. 