### PR TITLE
Marquee fixes - eager image load, `vertical-center` variant

### DIFF
--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -55,6 +55,8 @@ main > .section-outer > .section.marquee-container {
     min-height: 470px;
 }
 
+.marquee.vertical-center .foreground {  align-items: center; }
+
 .marquee.height-auto  .foreground {  min-height: unset; }
 
 .marquee .foreground > div {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -399,6 +399,19 @@ function loadDataLayer() {
   window.adobeDataLayer?.push(i);
 }
 
+async function waitForSectionImages(section) {
+  const lcpImages = section.querySelectorAll('img');
+  await Promise.all([...lcpImages].map((img) => new Promise((resolve) => {
+    if (!img.complete) {
+      img.setAttribute('loading', 'eager');
+      img.addEventListener('load', resolve, { once: true });
+      img.addEventListener('error', resolve, { once: true });
+    } else {
+      resolve();
+    }
+  })));
+}
+
 /**
  * Loads everything needed to get to LCP.
  * @param {Element} doc The container element
@@ -411,7 +424,7 @@ async function loadEager(doc) {
   if (main) {
     decorateMain(main, templateModule);
     document.body.classList.add('appear');
-    await loadSection(main.querySelector('.section'), waitForFirstImage);
+    await loadSection(main.querySelector('.section.marquee-container'), waitForSectionImages);
   }
 
   try {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -6,7 +6,6 @@ import {
   decorateSections,
   decorateBlocks,
   decorateTemplateAndTheme,
-  waitForFirstImage,
   loadSection,
   loadSections,
   decorateBlock,

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -36,9 +36,9 @@
   --calculator-input-color: #7d7d78;
 
   /* link text color */
-  --link-text-color: oklch(51.36% 0.0472 253.08deg);
-  --link-text-color-hover: oklch(32.77% 0.0522 253.54deg);
-  --link-text-color-visited: oklch(32.77% 0.0522 253.54deg);
+  --link-text-color: oklch(50.38% 0.0907 223.2deg); /* #0D6F8A - sky-blue-600 */
+  --link-text-color-hover: oklch(31.69% 0.0532 220.9deg); /* #083845 - sky-blue-800 */
+  --link-text-color-visited: oklch(31.69% 0.0532 220.9deg);
   --link-text-color-light: oklch(82% 0.09 264deg);
   --link-text-color-light-hover: oklch(92% 0.09 264deg);
   --link-text-color-light-visited: oklch(92% 0.09 264deg);


### PR DESCRIPTION
- Added load marquee image eager 
-- FYI, The defatult aem.js script looks for the first section single image. Which we have quick-links as the first section w/ no image so the marquee was missed
- Added marquee variant `vertical-center` to set this default on content mobile up. 
-- (no `-mobile` suffix needed since it's already vertically centered by default on desktop)

Fix [#341](https://github.com/aemsites/creditacceptance/issues/341) | [#319](https://github.com/aemsites/creditacceptance/issues/319)

1) Test URLs (eager loading):
- Before: https://main--creditacceptance--aemsites.aem.page/
- After: https://rparrish-marquee-bug--creditacceptance--aemsites.aem.page/

2) Test URLs (vertical-center):
- Before: https://main--creditacceptance--aemsites.aem.page/about/contact-us
- After: https://rparrish-marquee-bug--creditacceptance--aemsites.aem.page/about/contact-us

Check the 1st links that the marquee image(s) load eagerly instead of lazy
Check the 2nd links that the marquee content is vertically centered on mobile up. 

bonus: adjusted the link text to the latest feedback using sky-blues