### PR TITLE
#297 - Fix grid and add text block bg image options

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -17,7 +17,7 @@ header {
       z-index: 2;
       position: relative;
       background-color: var(--light-gray);
-      height: var(--header-height);
+      min-height: var(--header-height);
     }
     p { margin: 0; }
 

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -7,7 +7,7 @@ header {
   --menu-accent-orange: #ffb800;
 
     background-color: var(--light-gray);
-    height: var(--header-height);
+    min-height: var(--header-height);
     
     nav {
       padding: 0.5rem 1rem;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -7,7 +7,7 @@ header {
   --menu-accent-orange: #ffb800;
 
     background-color: var(--light-gray);
-    min-height: var(--header-height);
+    height: var(--header-height);
     
     nav {
       padding: 0.5rem 1rem;

--- a/blocks/text/text.css
+++ b/blocks/text/text.css
@@ -1,3 +1,46 @@
-/* Text */
+.text-block { 
+    position: relative;
+}
 
-/* .text-block { } */
+/* background */
+.text-block .background {
+    position: absolute;
+    z-index: -1;
+    height: 100%;
+    width: 100%;
+}
+
+.text-block .background picture {
+    height: 100%;
+}
+
+.text-block .background > div,
+.text-block .background > div p { 
+    margin: 0;
+    height: 100%; 
+}
+
+.text-block .background img,
+.text-block .background video {
+    object-fit: cover;
+    width: 100%;
+    height: 100%;
+}
+
+/* foreground */
+.text-block .foreground {
+    padding: 0;
+}
+
+/* inner-spacing */
+.text-block.inner-spacing-1 .foreground { padding: 1rem; }
+.text-block.inner-spacing-2 .foreground { padding: 2rem; }
+.text-block.inner-spacing-3 .foreground { padding: 3rem; }
+.text-block.inner-spacing-4 .foreground { padding: 4rem; }
+
+.text-block.max-width-50 .foreground { max-width: 50%; }
+.text-block.max-width-60 .foreground { max-width: 60%; }
+.text-block.max-width-70 .foreground { max-width: 70%; }
+.text-block.max-width-75 .foreground { max-width: 75%; }
+.text-block.max-width-80 .foreground { max-width: 80%; }
+.text-block.max-width-90 .foreground { max-width: 90%; }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -564,9 +564,6 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
   }
   
   &.gap-0 { gap: 0; }
-  &.gap-2 { gap: 2rem 0; }
-  &.gap-3 { gap: 3rem 0; }
-  &.gap-4 { gap: 4rem 0; }
 }
 
 .section.grid-section > .default-content-wrapper {
@@ -660,7 +657,12 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
 
     .grid-section {
         grid-template-columns: repeat(12, 1fr);
+        
+        &.gap-2 { gap: 2rem; }
+        &.gap-3 { gap: 3rem; }
+        &.gap-4 { gap: 4rem; }
     }
+    
 }
 
 @media screen and (width >= 1200px) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -411,8 +411,8 @@ button.secondary:hover {
   }
 }
 
-.marquee .background .tablet-only,
-.marquee .background .desktop-only {
+.block .background .tablet-only,
+.block .background .desktop-only {
     display: none;
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -545,25 +545,15 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
   grid-template-columns: 1fr;
   gap: 1rem;
 
-  .span-1 { grid-column: span 1; }
-  .span-2 { grid-column: span 2; }
-  .span-3 { grid-column: span 3; }
-  .span-4 { grid-column: span 4; }
-  .span-5 { grid-column: span 5; }
-  .span-6 { grid-column: span 6; }
-  .span-7 { grid-column: span 7; }
-  .span-8 { grid-column: span 8; }
-  .span-9 { grid-column: span 9; }
-  .span-10 { grid-column: span 10; }
-  .span-11 { grid-column: span 11; }
-  .span-12 { grid-column: span 12; }
-
   /* helpers */
   &.grid-justify-items-center {
       justify-items: center;
   }
   
   &.gap-0 { gap: 0; }
+  &.gap-2 { gap: 2rem; }
+  &.gap-3 { gap: 3rem; }
+  &.gap-4 { gap: 4rem; }
 }
 
 .section.grid-section > .default-content-wrapper {
@@ -616,7 +606,8 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
     padding-right: 0;
   }
 
-  .block .background .tablet-only {
+  .block .background .tablet-only,
+  .block .background .tablet-only.desktop-only {
     display: block;
   }
 
@@ -658,9 +649,18 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
     .grid-section {
         grid-template-columns: repeat(12, 1fr);
         
-        &.gap-2 { gap: 2rem; }
-        &.gap-3 { gap: 3rem; }
-        &.gap-4 { gap: 4rem; }
+        .span-1 { grid-column: span 1; }
+        .span-2 { grid-column: span 2; }
+        .span-3 { grid-column: span 3; }
+        .span-4 { grid-column: span 4; }
+        .span-5 { grid-column: span 5; }
+        .span-6 { grid-column: span 6; }
+        .span-7 { grid-column: span 7; }
+        .span-8 { grid-column: span 8; }
+        .span-9 { grid-column: span 9; }
+        .span-10 { grid-column: span 10; }
+        .span-11 { grid-column: span 11; }
+        .span-12 { grid-column: span 12; }
     }
     
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -564,9 +564,9 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
   }
   
   &.gap-0 { gap: 0; }
-  &.gap-2 { gap: 2rem; }
-  &.gap-3 { gap: 3rem; }
-  &.gap-4 { gap: 0; }
+  &.gap-2 { gap: 2rem 0; }
+  &.gap-3 { gap: 3rem 0; }
+  &.gap-4 { gap: 4rem 0; }
 }
 
 .section.grid-section > .default-content-wrapper {
@@ -617,6 +617,15 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
     max-width: var(--container-width);
     padding-left: 0;
     padding-right: 0;
+  }
+
+  .block .background .tablet-only {
+    display: block;
+  }
+
+  .block .background .mobile-only,
+  .block .background .desktop-only {
+      display: none;
   }
 
   :root {  --container-width: 540px; }


### PR DESCRIPTION
- Fixed the grid so the `span-*` elements only apply on desktop up
-- This was causing some issues w/ using a gap w/ grids on mobile/tablet - See the before link form section
- Added options for bg images on a text block - @jordanpetersen27 asked for this as a general option when [prototyping pages](https://rparrish-text-bg--creditacceptance--aemsites.aem.page/campaign/bhph-v2). 

Fix [#297](https://github.com/aemsites/creditacceptance/issues/297)

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/campaign/bhph
- After: https://rparrish-text-bg--creditacceptance--aemsites.aem.page/campaign/bhph

Testing criteria - Check the grid elements take up full span-12 on mobile VP. 