### PR TITLE
Columns w/ Icons 

### DIFF
--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -98,6 +98,11 @@
     transform: translateY(-50%) rotate(135deg);
 }
 
+
+.accordion.arrow details summary span.icon {
+    vertical-align: baseline;
+}
+
 .accordion details .accordion-item-body {
     padding-block: 0;
     padding-inline: 52px 16px;

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -229,7 +229,6 @@
   display: flex;
   gap: 1.2rem;
   justify-content: center;
-  top: -100%;
   position: relative;
 
   .icon.icon-googleplay-badge,

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -326,6 +326,21 @@
     }
 }
 
+.columns.big-icons .copy:has(.icon-elm) {
+    p, h2, h3, h4, h5, h6 {
+        padding-inline-start: unset;
+        
+        .icon {
+            position: relative;
+            left: unset;
+            top: unset;
+            width: 60px;
+            height: auto;
+        }
+    }
+    
+}
+
 
 /* mobile-tablet only */
 @media screen and (width <= 959px) {
@@ -333,19 +348,19 @@
         display: none;
     }
 
-    .columns.big-icons .copy {
+    .columns.big-icons > div {
       display: grid;
-      grid-template-columns: 24px 1fr;
+      grid-template-columns: 60px 1fr;
       grid-template-rows: auto auto;
-      gap: 0 32px;
+      gap: 0 1.5rem;
     }
   
-    .columns.big-icons .copy > p:first-of-type {
+    .columns.big-icons > div:first-of-type {
       grid-row: span 2;
       align-self: center;
     }
   
-    .columns.big-icons .copy > p:not(:first-of-type) {
+    .columns.big-icons .> div:not(:first-of-type) {
       margin-top: 0;
     }
 }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -5,12 +5,12 @@
   gap: 0 1.5rem;
 }
 
-.columns.columns-2-cols > div { gap: 3rem; }
+.columns.columns-2-cols > div { gap: 0 3rem; }
 .columns.gap-0 > div { gap: 0; }
-.columns.gap-1 > div { gap: 1rem; }
-.columns.gap-2 > div { gap: 2rem; }
-.columns.gap-3 > div { gap: 3rem; }
-.columns.gap-4 > div { gap: 4rem; }
+.columns.gap-1 > div { gap: 0 1rem; }
+.columns.gap-2 > div { gap: 0 2rem; }
+.columns.gap-3 > div { gap: 0 3rem; }
+.columns.gap-4 > div { gap: 0 4rem; }
 
 .columns img {
   width: 100%;
@@ -231,6 +231,12 @@
   justify-content: center;
   top: -100%;
   position: relative;
+
+  .icon.icon-googleplay-badge,
+  .icon.icon-app-store-badge {
+    margin-top: 1rem;
+    width: 135px;
+  }
 }
 
 .columns.dot-separator > div {
@@ -299,22 +305,27 @@
     border-top: 2px solid var(--pure-black);
 } 
 
-.columns ul.col-icon-list {
-    margin: 0;
-    padding-inline-start: 40px;
-    
-    h2, h3, h4, h5, h6 {
-        position: relative;
 
+.columns .copy:has(.icon-elm) {
+    p, h2, h3, h4, h5, h6 {
+        padding-inline-start: 40px;
+        position: relative;
+        
         .icon {
             position: absolute;
-            left: -40px;
+            left: 0;
             top: 0;
             width: 24px;
             height: 24px;
-        }
+        }    
+    }
+
+    .divider-thin-blue-dot {
+        margin: 1rem 0 1rem 40px;
+        width: auto;
     }
 }
+
 
 /* mobile-tablet only */
 @media screen and (width <= 959px) {

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -360,7 +360,7 @@
       align-self: center;
     }
   
-    .columns.big-icons .> div:not(:first-of-type) {
+    .columns.big-icons > div:not(:first-of-type) {
       margin-top: 0;
     }
 }

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -71,12 +71,18 @@ function decorateColumnsCalculation(block) {
   });
 }
 
-function decorateColIconList(col) {
-  const colHeader = col.querySelector('h1, h2, h3, h4, h5, h6');
-  const colHeaderIcon = colHeader?.querySelector('.icon');
-  if (!colHeader && !colHeaderIcon) return;
-  const colContentWrapper = createTag('ul', { class: 'col-icon-list' }, [...col.children]);
-  col.append(colContentWrapper);
+function decorateColIconGroup(col) {
+  const colIcons = col.querySelectorAll('.icon');
+  if (!colIcons) return;
+  colIcons.forEach((icon) => {
+    const parent = icon.parentElement;
+    if (parent) {
+      const parentTagName = parent.tagName.toLowerCase();
+      if (parentTagName === 'p' || parentTagName === 'h1' || parentTagName === 'h2' || parentTagName === 'h3' || parentTagName === 'h4' || parentTagName === 'h5' || parentTagName === 'h6') {
+        parent.classList.add('icon-elm');
+      }
+    }
+  });
 }
 
 function applyStatsClasses(block) {
@@ -105,7 +111,7 @@ export default function decorate(block) {
       } else {
         col.classList.add('copy');
       }
-      decorateColIconList(col);
+      decorateColIconGroup(col);
     });
   });
   // flex basis

--- a/blocks/quick-links/quick-links.css
+++ b/blocks/quick-links/quick-links.css
@@ -6,6 +6,7 @@
     display: flex;
     flex-wrap: wrap;
     padding: 0;
+    margin: 0;
 }
 
 .quick-links nav ul li {

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -152,7 +152,6 @@ export function decorateGridSection(section, meta) {
       }
       rowCount += 1;
     });
-
   if (autoGrid) { section.classList.add(`grid-template-columns-${rowCount}-auto`); }
 }
 
@@ -171,7 +170,9 @@ export function decorateGridSectionGroups(section, meta) {
       currentDiv.append(child);
     }
   });
-  const gridValues = meta.split(',');
+  const gridValues = meta.split(',').map((val) => val.trim().toLowerCase());
+  let rowCount = 0;
+  let autoGrid = false;
   section.classList.add('grid-section');
   const gridRows = [...sectionRows];
   gridRows.forEach((row, i) => {
@@ -182,11 +183,17 @@ export function decorateGridSectionGroups(section, meta) {
         child.replaceWith(...child.childNodes);
       }
     });
-    const spanVal = gridValues[i].trim();
-    if (spanVal) row.classList.add(spanVal.toLowerCase());
+    if (gridValues[i]) row.classList.add(gridValues[i]);
+    // if single span-auto row, add span-auto class to all rows
+    if (gridValues[0] === 'span-auto' && gridValues.length === 1) {
+      row.classList.add('span-auto');
+      autoGrid = true;
+    }
+    rowCount += 1;
   });
 
   section.append(...gridRows);
+  if (autoGrid) { section.classList.add(`grid-template-columns-${rowCount}-auto`); }
 }
 
 function updateActiveSlide(steps, pagination) {

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -133,7 +133,8 @@ export async function decorateBlockBg(block, node, { useHandleFocalpoint = false
 export function decorateGridSection(section, meta) {
   section.classList.add('grid-section');
   const gridValues = meta.split(',').map((val) => val.trim().toLowerCase());
-
+  let rowCount = 0;
+  let autoGrid = false;
   Array.from(section.querySelectorAll('.section > div'))
     .filter((row) => {
       const firstCol = row.querySelector(':scope > div');
@@ -144,7 +145,15 @@ export function decorateGridSection(section, meta) {
       if (gridValues[i]) {
         row.classList.add(gridValues[i]);
       }
+      // if single span-auto row, add span-auto class to all rows
+      if (gridValues[0] === 'span-auto' && gridValues.length === 1) {
+        row.classList.add('span-auto');
+        autoGrid = true;
+      }
+      rowCount += 1;
     });
+
+  if (autoGrid) { section.classList.add(`grid-template-columns-${rowCount}-auto`); }
 }
 
 export function decorateGridSectionGroups(section, meta) {

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+/* eslint-disable func-names */
 
 // delay loading of GTM script until after the page has loaded
 import { isProductionEnvironment } from '../libs/utils/utils.js';

--- a/scripts/googletagmanager-worker.js
+++ b/scripts/googletagmanager-worker.js
@@ -1,5 +1,5 @@
 // Listen for messages from the main thread
-onmessage = function (event) {
+onmessage = function onmessage(event) {
   if (event.data === 'loadGTMDev') {
     fetch('https://www.googletagmanager.com/gtm.js?id=GTM-NXTTWP')
       .then((response) => response.text())

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -48,8 +48,8 @@
   --btn-primary-bg-hover: oklch(73% 0.14 81.97deg);
   --btn-primary-blue-bg: oklch(92% 0.05 217deg);
   --btn-primary-blue-bg-hover: oklch(88% 0.1 217deg);
-  --btn-secondary-border: oklch(92% 0.05 217deg);
-  --btn-secondary-border-hover: oklch(88% 0.1 217deg);
+  --btn-secondary-border: oklch(38% 0.06 254.57deg);
+  --btn-secondary-border-hover: oklch(27% 0.05 238.22deg);
 
   /* borders */
   --bs-border-color: #dee2e6;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -46,10 +46,10 @@
   /* buttons */
   --btn-primary-bg: oklch(83% 0.17 81.97deg / 100%);
   --btn-primary-bg-hover: oklch(73% 0.14 81.97deg);
-  --btn-primary-blue-bg: oklch(91% 0.11 233.5deg);
-  --btn-primary-blue-bg-hover: oklch(84% 0.11 233.5deg);
-  --btn-secondary-border: oklch(38% 0.06 254.57deg / 100%);
-  --btn-secondary-border-hover: oklch(27% 0.05 238.22deg / 100%);
+  --btn-primary-blue-bg: oklch(92% 0.05 217deg);
+  --btn-primary-blue-bg-hover: oklch(88% 0.1 217deg);
+  --btn-secondary-border: oklch(92% 0.05 217deg);
+  --btn-secondary-border-hover: oklch(88% 0.1 217deg);
 
   /* borders */
   --bs-border-color: #dee2e6;
@@ -564,19 +564,6 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
   grid-template-columns: 1fr;
   gap: 1rem;
 
-  .span-1 { grid-column: span 1; }
-  .span-2 { grid-column: span 2; }
-  .span-3 { grid-column: span 3; }
-  .span-4 { grid-column: span 4; }
-  .span-5 { grid-column: span 5; }
-  .span-6 { grid-column: span 6; }
-  .span-7 { grid-column: span 7; }
-  .span-8 { grid-column: span 8; }
-  .span-9 { grid-column: span 9; }
-  .span-10 { grid-column: span 10; }
-  .span-11 { grid-column: span 11; }
-  .span-12 { grid-column: span 12; }
-
   /* helpers */
   &.grid-justify-items-center {
       justify-items: center;
@@ -675,6 +662,34 @@ header {
 
     .grid-section {
         grid-template-columns: repeat(12, 1fr);
+
+        .span-1 { grid-column: span 1; }
+        .span-2 { grid-column: span 2; }
+        .span-3 { grid-column: span 3; }
+        .span-4 { grid-column: span 4; }
+        .span-5 { grid-column: span 5; }
+        .span-6 { grid-column: span 6; }
+        .span-7 { grid-column: span 7; }
+        .span-8 { grid-column: span 8; }
+        .span-9 { grid-column: span 9; }
+        .span-10 { grid-column: span 10; }
+        .span-11 { grid-column: span 11; }
+        .span-12 { grid-column: span 12; }
+        .span-auto { grid-column: initial; }
+
+
+        &.grid-template-columns-1-auto { grid-template-columns: repeat(1, auto); }
+        &.grid-template-columns-2-auto { grid-template-columns: repeat(2, auto); }
+        &.grid-template-columns-3-auto { grid-template-columns: repeat(3, auto); }
+        &.grid-template-columns-4-auto { grid-template-columns: repeat(4, auto); }
+        &.grid-template-columns-5-auto { grid-template-columns: repeat(5, auto); }
+        &.grid-template-columns-6-auto { grid-template-columns: repeat(6, auto); }
+        &.grid-template-columns-7-auto { grid-template-columns: repeat(7, auto); }
+        &.grid-template-columns-8-auto { grid-template-columns: repeat(8, auto); }
+        &.grid-template-columns-9-auto { grid-template-columns: repeat(9, auto); }
+        &.grid-template-columns-10-auto { grid-template-columns: repeat(10, auto); }
+        &.grid-template-columns-11-auto { grid-template-columns: repeat(11, auto); }
+        &.grid-template-columns-12-auto { grid-template-columns: repeat(12, auto); }
     }
 }
 


### PR DESCRIPTION
 - accordion header icon alignment
 - adjusted column icon-elem styles and logic to display icon margin in p and header tags
 - added option to section-metadata: grid | span-auto - (see the customers `V2` page w/ a single quick-link button/title)
 - fixed `btn.blue` brand colors

Fix 
- Icon wrapping for `<p>` - [357](https://github.com/aemsites/creditacceptance/issues/357)
- UL accessiblity - [#366](https://github.com/aemsites/creditacceptance/issues/366)
- Big-icons - [373](https://github.com/aemsites/creditacceptance/issues/373)

Customers pg: (column-icons)
- Before: https://main--creditacceptance--aemsites.aem.page/customers
- After: https://rparrish-column-icons--creditacceptance--aemsites.aem.page/customers

Contact Us pg: (grid-auto, column-icons) - I added a V2 page w/ updated authoring. This is the preferred page
- Before: https://main--creditacceptance--aemsites.aem.page/about/contact-us
-- Before: https://main--creditacceptance--aemsites.aem.page/about/contact-us-v2
- After: https://rparrish-column-icons--creditacceptance--aemsites.aem.page/about/contact-us
-- After: https://rparrish-column-icons--creditacceptance--aemsites.aem.page/about/contact-us-v2

Network pg: (big-icons)
- Before: https://main--creditacceptance--aemsites.aem.page/dealers/join-our-network
- After: https://rparrish-column-icons--creditacceptance--aemsites.aem.page/dealers/join-our-network

Testing criteria - Check links against the live site and make sure all looks the same. (for the most part 😉)
Live site
https://www.creditacceptance.com/customers
https://main--creditacceptance--aemsites.aem.page/about/contact-us
https://main--creditacceptance--aemsites.aem.page/dealers/join-our-network