### PR TITLE
Button decorator fix to address missing buttons

### DIFF
--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -13,6 +13,8 @@
 main > .section-outer > .section.tabs-container {
     max-width: 100%;
     margin: 0;
+    padding-left: 0;
+    padding-right: 0;
 }
 
 .tabs {

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -43,24 +43,24 @@ export function decorateButtons(el) {
   if (buttons.length === 0) return;
   const buttonTypeMap = { STRONG: 'primary', EM: 'secondary', A: 'link' };
   buttons.forEach((button) => {
-    let target = button;
     const parent = button.parentElement;
     const buttonType = buttonTypeMap[parent.nodeName] || 'primary';
-    if (button.nodeName === 'STRONG') {
-      target = parent;
-    } else {
-      parent.insertAdjacentElement('afterend', button);
-      parent.remove();
-    }
-    target.classList.add('button', buttonType);
-    const customClasses = target.textContent && [...target.textContent.matchAll(/#_button-([a-zA-Z-]+)/g)];
+    button.classList.add('button', buttonType);
+
+    const customClasses = button.textContent && [...button.textContent.matchAll(/#_button-([a-zA-Z-]+)/g)];
     if (customClasses) {
       customClasses.forEach((match) => {
-        target.textContent = target.textContent.replace(match[0], '');
-        target.classList.add(match[1]);
+        button.textContent = button.textContent.replace(match[0], '');
+        button.classList.add(match[1]);
       });
     }
-    button.parentElement?.classList.add('button-container');
+  });
+  // remove wrapping tags and add button-container class to parent p
+  el.querySelectorAll('p > strong, p > em').forEach((btn) => {
+    const parentP = btn.parentElement;
+    btn.querySelectorAll('a').forEach((a) => parentP.appendChild(a));
+    btn.remove();
+    parentP.classList.add('button-container');
   });
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -395,7 +395,7 @@ button.secondary {
   border-radius: 19px;
   background-color: var(--very-light-gray);
   color: var(--btn-secondary-border);
-  padding: .3rem 2rem;
+  padding: .4rem 2rem 0;
   transition: box-shadow 0.2s ease-in-out, color 0.2s ease-in-out; /* Add transition for smooth effect */
 }
 
@@ -408,6 +408,12 @@ button.secondary:hover {
 }
 
 /* Buttons Container */
+.button-container {
+  display: flex;
+  flex-flow: row wrap;
+  gap: .75rem;
+}
+
 .buttons-container {
   display: flex;
   flex-flow: row wrap;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -395,7 +395,7 @@ button.secondary {
   border-radius: 19px;
   background-color: var(--very-light-gray);
   color: var(--btn-secondary-border);
-  padding: .4rem 2rem 0;
+  padding: .3rem 2rem;
   transition: box-shadow 0.2s ease-in-out, color 0.2s ease-in-out; /* Add transition for smooth effect */
 }
 


### PR DESCRIPTION
When an author adds multiple buttons on the same line, It is easy to overlook the 'styled' space between items resulting in them having a shared element and the button decorator will remove nth(2+) children. 

- Fixed button logic to address when authoring multiple buttons that share a decorator tag `<span> || <em>`

Fix [#347](https://github.com/aemsites/creditacceptance/issues/347)

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/rparrish/inline-buttons
- After: https://rparrish-btns--creditacceptance--aemsites.aem.page/drafts/rparrish/inline-buttons

Regression URLS
- Before: https://main--creditacceptance--aemsites.aem.page/
- After: https://rparrish-btns--creditacceptance--aemsites.aem.page/

Testing criteria - Check that all the authored buttons show on the frontend on the after link and there are no regression issues. 

⭐ bonus: fixed tabs block on mobile. removed l/r padding so tab-list gradient went full bleed on mobile