### PR TITLE
Cards allow any header h2-h6

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -224,11 +224,6 @@
      flex-direction: column;
  }
 
- .cards.resources>ul>li h3 {
-     padding: 48px 0;
-     font-size: 32px;
- }
-
  .cards.resources>ul>li .card-wrapper {
      padding: 1rem 1.5rem;
      background: var(--very-light-gray);
@@ -323,7 +318,11 @@
      flex-shrink: 0;
  }
 
+ .cards.resources.center .cards-card-body h2,
+ .cards.resources.center .cards-card-body h3,
  .cards.resources.center .cards-card-body h4,
+ .cards.resources.center .cards-card-body h5,
+ .cards.resources.center .cards-card-body h6,
  .cards.resources.center .cards-card-body p:not(.button-container) {
      text-align: left;
  }

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -318,6 +318,11 @@
      flex-shrink: 0;
  }
 
+ .cards.resources>ul>li .card-intro {
+    padding: 48px 0;
+    font-size: 32px;
+}
+
  .cards.resources.center .cards-card-body h2,
  .cards.resources.center .cards-card-body h3,
  .cards.resources.center .cards-card-body h4,

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -81,20 +81,13 @@ export default function decorate(block) {
     if (isAnimated) li.classList.add('animation-scale');
     const cardWrapper = createTag('div', { class: 'card-wrapper' });
     while (row.firstElementChild) cardWrapper.append(row.firstElementChild);
-    let heading = null;
     [...cardWrapper.children].forEach((div) => {
       if (div.querySelector('picture')) {
         div.className = 'cards-card-image';
         decoratePictures(div);
       } else {
         div.className = 'cards-card-body';
-        const h3 = div.querySelector('h3');
-        if (h3) {
-          heading = h3;
-          div.removeChild(h3);
-        }
-
-        const cardTitle = div.querySelector('h4, h5, h6');
+        const cardTitle = div.querySelector('h2, h3, h4, h5, h6');
         cardTitle?.classList.add('card-title');
 
         const paragraphs = div.querySelectorAll('p');
@@ -111,7 +104,6 @@ export default function decorate(block) {
         icon.parentNode.parentNode.replaceWith(maskedDiv);
       }
     });
-    if (heading) li.append(heading);
     li.append(cardWrapper);
     ul.append(li);
   });

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -76,10 +76,12 @@ function decoratePictures(cell) {
 export default function decorate(block) {
   const isAnimated = block.classList.contains('animation') && !block.classList.contains('animation-none');
   const ul = createTag('ul');
+  const resourcesType = block.classList.contains('resources');
   [...block.children].forEach((row) => {
     const li = createTag('li');
     if (isAnimated) li.classList.add('animation-scale');
     const cardWrapper = createTag('div', { class: 'card-wrapper' });
+    let cardIntro = null;
     while (row.firstElementChild) cardWrapper.append(row.firstElementChild);
     [...cardWrapper.children].forEach((div) => {
       if (div.querySelector('picture')) {
@@ -87,9 +89,15 @@ export default function decorate(block) {
         decoratePictures(div);
       } else {
         div.className = 'cards-card-body';
-        const cardTitle = div.querySelector('h2, h3, h4, h5, h6');
-        cardTitle?.classList.add('card-title');
-
+        const cardheaders = div.querySelectorAll('h2, h3, h4, h5, h6');
+        cardheaders.forEach((header, i) => {
+          if (cardheaders.length > 1 && i === 0 && resourcesType) {
+            cardIntro = header;
+            cardIntro.classList.add('card-intro');
+          } else {
+            header?.classList.add('card-title');
+          }
+        });
         const paragraphs = div.querySelectorAll('p');
         decorateDate(paragraphs);
 
@@ -104,6 +112,7 @@ export default function decorate(block) {
         icon.parentNode.parentNode.replaceWith(maskedDiv);
       }
     });
+    if (cardIntro) li.append(cardIntro);
     li.append(cardWrapper);
     ul.append(li);
   });


### PR DESCRIPTION
Updated logic to allow any header (h2-h6) in a card and if there are 2, the first one becomes the card-intro in `grid -> <li>` but outside of .card for (resources) type. 

Fix [#367](https://github.com/aemsites/creditacceptance/issues/367)

Draft URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/rparrish/cards-resources
- After: https://rparrish-cards-htag--creditacceptance--aemsites.aem.page/drafts/rparrish/cards-resources

Live URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/campaign/200-promo
- After: https://rparrish-cards-htag--creditacceptance--aemsites.aem.page/campaign/200-promo

Testing criteria - Author should expect any header to be author able in a card block. If using the variant (resources) and authored w/ 2 headers, The first one will become the `card-intro`