### PR TITLE
Grid reverse on mobile

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -365,7 +365,7 @@
 }
 
 @media screen and (width < 576px) {
-  .columns.col-mobile-reverse > div {
+  .columns.col-mobile-reverse > div, .columns.column-reverse-mobile > div {
     flex-direction: column-reverse;
   }
 }

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -57,6 +57,7 @@ export function decorateButtons(el) {
   });
   // remove wrapping tags and add button-container class to parent p
   el.querySelectorAll('p > strong, p > em').forEach((btn) => {
+    if (!btn.querySelector('a')) return;
     const parentP = btn.parentElement;
     btn.querySelectorAll('a').forEach((a) => parentP.appendChild(a));
     btn.remove();

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -650,8 +650,8 @@ header {
 }
 
 /* Reverse order of grids in mobile view */
-@media (width <= 576px) {
-  .grid-section.col-mobile-reverse {
+@media (width < 960px) {
+  .grid-section.column-reverse-mobile {
     display: flex;
     flex-direction: column-reverse;
   }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -649,6 +649,14 @@ header {
   :root {  --container-width: 540px; }
 }
 
+/* Reverse order of grids in mobile view */
+@media (width <= 576px) {
+  .grid-section.col-mobile-reverse {
+    display: flex;
+    flex-direction: column-reverse;
+  }
+}
+
 @media screen and (width >= 768px) {
     :root { --container-width: 720px; }
 }


### PR DESCRIPTION
An option to reverse grid on mobile.

We already have a col-mobile-reverse for columns. extending that to grids.

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/kailas/join-our-network
- After: https://btn-fix--creditacceptance--aemsites.aem.page/drafts/kailas/join-our-network
