### PR TITLE
remove padding on defatult section for `image-text-overlay`

### DIFF
--- a/blocks/image-text-overlay/image-text-overlay.css
+++ b/blocks/image-text-overlay/image-text-overlay.css
@@ -1,6 +1,5 @@
 main > .section-outer > .section.image-text-overlay-container {
   max-width: 100%;
-  padding: 0;
   margin: 0;
 }
 


### PR DESCRIPTION
Removed the block default section padding so it can be authored. 
- The slider works on mobile w/ a refresh, not resize

Fix [#412](https://github.com/aemsites/creditacceptance/issues/412)

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/
- After: https://rparrish-img-txt-padding--creditacceptance--aemsites.aem.page/

Testing criteria - make sure the block, `[image-text-overlay]` has authored spacing 