### PR TITLE
Performance improvement - mobile images on marque

### DIFF
--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -82,7 +82,7 @@ function decoratePictures(el) {
     const img = picture.querySelector('img');
     if (!img) return;
     const isMobilePic = picture.closest('div').classList.contains('mobile-only');
-    const breakpoints = isMobilePic ? [{ media: '(min-width: 600px)', width: '2000' }, { width: '450' }] : [{ media: '(min-width: 600px)', width: '2000' }, { width: '450' }];
+    const breakpoints = isMobilePic ? [{ media: '(min-width: 600px)', width: '600' }, { width: '450' }] : [{ media: '(min-width: 600px)', width: '2000' }, { width: '750' }];
     const optimizedPicture = createOptimizedPicture(img.src, img.alt, true, breakpoints);
     picture.replaceWith(optimizedPicture);
   });

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -81,8 +81,9 @@ function decoratePictures(el) {
   pictures.forEach((picture) => {
     const img = picture.querySelector('img');
     if (!img) return;
-    const optimizedPicture = createOptimizedPicture(img.src, img.alt);
-    console.log('picture', picture, 'optimizedPicture', optimizedPicture);
+    const isMobilePic = picture.closest('div').classList.contains('mobile-only');
+    const breakpoints = isMobilePic ? [{ media: '(min-width: 600px)', width: '2000' }, { width: '450' }] : [{ media: '(min-width: 600px)', width: '2000' }, { width: '450' }];
+    const optimizedPicture = createOptimizedPicture(img.src, img.alt, true, breakpoints);
     picture.replaceWith(optimizedPicture);
   });
 }

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -1,6 +1,6 @@
 import { createTag } from '../../libs/utils/utils.js';
 import { decorateBlockBg, isDarkHexColor } from '../../libs/utils/decorate.js';
-import { loadCSS } from '../../scripts/aem.js';
+import { createOptimizedPicture, loadCSS } from '../../scripts/aem.js';
 
 function isDarkColor(colors, colorStr) {
   const colorObject = colors.find((c) => c['brand-name'] === colorStr);
@@ -76,12 +76,24 @@ function initAnimatedMarquee(block) {
   }, '8000');
 }
 
+function decoratePictures(el) {
+  const pictures = el.querySelectorAll('picture');
+  pictures.forEach((picture) => {
+    const img = picture.querySelector('img');
+    if (!img) return;
+    const optimizedPicture = createOptimizedPicture(img.src, img.alt);
+    console.log('picture', picture, 'optimizedPicture', optimizedPicture);
+    picture.replaceWith(optimizedPicture);
+  });
+}
+
 export default function decorate(block) {
   const children = block.querySelectorAll(':scope > div');
   const foreground = children[children.length - 1];
   const background = children.length > 1 ? children[0] : null;
   if (background) {
     decorateBlockBg(block, background, { useHandleFocalpoint: true });
+    decoratePictures(background);
   }
   foreground.classList.add('foreground', 'container');
   decorateIntro(foreground);


### PR DESCRIPTION
Used aem.js `createOptimizedPicture()` method to pass in optional breakpoint size param for our mobile images on marquee. 

Fix [#395](https://github.com/aemsites/creditacceptance/issues/395)

Test URLs:
before: https://main--creditacceptance--aemsites.aem.page/
after: https://rparrish-mobile-img--creditacceptance--aemsites.aem.page/

Testing criteria - check the inspector network tab to confirm the mobile image is smaller. 

![image](https://github.com/user-attachments/assets/e7919023-f0c3-4db5-9caf-61b6bd05f7e3)
