### PR TITLE
#433 - fix footer spacing issues

### DIFF
--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -1,4 +1,4 @@
-.accordion-container > .accordion-wrapper+.default-content-wrapper:not(:has(> .divider)) {
+.accordion-container > .default-content-wrapper ~ .default-content-wrapper:not(:has(> .divider)) {
     margin-block: 84px 0;
 }
 

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -8,15 +8,12 @@ footer .footer>div {
     padding: 0 12px 12px;
 }
 
-footer .footer .accordion-container {
-    padding-top: 0;
+footer .footer .accordion-container,
+footer .footer .default-content-wrapper {
+    padding-block: 0;
 }
 
 footer .footer .accordion-wrapper {
-    margin-top: 0;
-}
-
-footer .footer .accordion-container .default-content-wrapper {
     margin-top: 0;
 }
 
@@ -33,6 +30,7 @@ footer .footer p {
 }
 
 .footer .default-content-wrapper ul li {
+    margin: 0;
     padding-inline: 12px;
     list-style-type: none;
     font-size: 12px;
@@ -120,6 +118,7 @@ footer .accordion.sitemap details summary .accordion-item-minus {
 
 .footer .accordion.sitemap .accordion-item-body ul li {
     list-style-type: none;
+    margin: 0;
     padding-block-end: 8px;
 }
 


### PR DESCRIPTION
Remove footer spacings, also fixes spacing for `li` items used for links

Fix #433 

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/
- After: https://smalla-433--creditacceptance--aemsites.aem.page/

Testing criteria - Footer spacings
For regression - Spacing between FAQ headings - https://smalla-433--creditacceptance--aemsites.aem.page/customers/faq