### PR TITLE
Fix #390 - fix big icons on mobile

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -347,20 +347,15 @@
         display: none;
     }
 
-    .columns.big-icons > div {
-      display: grid;
-      grid-template-columns: 60px 1fr;
-      grid-template-rows: auto auto;
-      gap: 0 1.5rem;
+    .columns.big-icons .copy:first-of-type > :is(p:not(.icon-elm), h4),
+    .columns.big-icons .copy:has(.icon-elm) + .copy > :is(p:not(.icon-elm), h4) {
+        margin-inline-start: 80px;
     }
-  
-    .columns.big-icons > div:first-of-type {
-      grid-row: span 2;
-      align-self: center;
-    }
-  
-    .columns.big-icons > div:not(:first-of-type) {
-      margin-top: 0;
+
+    .columns.big-icons .copy .icon-elm  span.icon{
+        position: absolute;
+        left: 0;
+        top: 0;
     }
 }
 


### PR DESCRIPTION
Fix `big-icons` variant of columns on mobile

Fix #390 

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/smalla/big-icons
- After: https://smalla-390--creditacceptance--aemsites.aem.page/drafts/smalla/big-icons

Page `/careers` - https://smalla-390--creditacceptance--aemsites.aem.page/careers 
Testing criteria - On mobile screen, big icons shouldn't cause layout issue.

For Regression - 
- https://smalla-390--creditacceptance--aemsites.aem.page
- https://smalla-390--creditacceptance--aemsites.aem.page/dealers/join-our-network