### PR TITLE
Marquee image and top nav overlapping

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -344,10 +344,12 @@
 
 
 /* mobile-tablet only */
-@media screen and (width <= 959px) {
+@media screen and (width < 960px) {
     .columns.media-hidden-mobile .media-count-1 {
         display: none;
     }
+
+    .columns .media { margin-bottom: 1.5rem; }
 
     .columns.big-icons > div {
       display: grid;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -10,10 +10,11 @@ header {
     height: var(--header-height);
     
     nav {
-      padding: 0.5rem 1rem;
+      padding: 0 1rem;
       margin: 0 auto;
       display: flex;
       flex-direction: column;
+      justify-content: center;
       z-index: 2;
       position: relative;
       background-color: var(--light-gray);

--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -63,6 +63,8 @@ main > .section-outer > .section.marquee-container {
     padding: 2em 1em;
 }
 
+.marquee .heading { display: inline; }
+
 .marquee p.intro {
     color: black;
     margin-bottom: 1rem;
@@ -79,7 +81,7 @@ main > .section-outer > .section.marquee-container {
     padding: .5rem .5rem .25rem;
 }
 
-.marquee p.intro div {
+.marquee p.intro .border {
     height: 2px;
     background: var(--very-light-gray);
     position: absolute;
@@ -106,11 +108,6 @@ main > .section-outer > .section.marquee-container {
 .marquee.max-width-75 .foreground > div {
     max-width: 75%;
     width: 75%
-}
-
-.marquee.max-width-90 .foreground > div {
-    max-width: 90%;
-    width: 90%
 }
 
 .marquee.max-width-100 .foreground > div {
@@ -145,11 +142,13 @@ main > .section-outer > .section.marquee-container {
         max-width: 50%;
     }
     
-    .marquee.max-width-75-desktop .foreground > div { max-width: 75%; }
-
-    .marquee.max-width-90-desktop .foreground > div { max-width: 90%; }
+    .marquee.max-width-75-desktop .foreground > div {
+        max-width: 75%;
+    }
     
-    .marquee.max-width-100-desktop .foreground > div { max-width: 100%; }
+    .marquee.max-width-100-desktop .foreground > div {
+        max-width: 100%;
+    }
 
     .marquee .action-area {
         gap: 1rem;

--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -108,6 +108,11 @@ main > .section-outer > .section.marquee-container {
     width: 75%
 }
 
+.marquee.max-width-90 .foreground > div {
+    max-width: 90%;
+    width: 90%
+}
+
 .marquee.max-width-100 .foreground > div {
     max-width: 100%;
     width: 100%
@@ -140,13 +145,11 @@ main > .section-outer > .section.marquee-container {
         max-width: 50%;
     }
     
-    .marquee.max-width-75-desktop .foreground > div {
-        max-width: 75%;
-    }
+    .marquee.max-width-75-desktop .foreground > div { max-width: 75%; }
+
+    .marquee.max-width-90-desktop .foreground > div { max-width: 90%; }
     
-    .marquee.max-width-100-desktop .foreground > div {
-        max-width: 100%;
-    }
+    .marquee.max-width-100-desktop .foreground > div { max-width: 100%; }
 
     .marquee .action-area {
         gap: 1rem;

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -8,16 +8,22 @@ function isDarkColor(colors, colorStr) {
   return isDarkHexColor(colorObject['color-value']);
 }
 
+function setTitleBorderWidth(heading, border) {
+  const headerWidth = heading.getBoundingClientRect().width;
+  border.style.width = `${headerWidth}px`;
+}
+
 function decorateIntro(el) {
   const heading = el.querySelector('h1, h2, h3, h4, h5, h6');
   if (!heading) return;
   const intro = heading.previousElementSibling;
   if (!intro) return;
   intro.classList.add('intro');
+  heading.classList.add('heading');
   const [text, color] = intro.textContent.trim().split('{');
   intro.innerHTML = '';
   const label = createTag('span', null, text.trim());
-  const border = createTag('div');
+  const border = createTag('div', { class: 'border' });
   intro.appendChild(label);
   intro.appendChild(border);
   if (color) {
@@ -36,6 +42,14 @@ function decorateIntro(el) {
       });
     }
   }
+  // Auto-toggle every 8 seconds
+  setTimeout(() => {
+    setTitleBorderWidth(heading, border);
+  }, '100');
+
+  window.addEventListener('resize', () => {
+    setTitleBorderWidth(heading, border);
+  });
 }
 
 function addCoins(el) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -87,7 +87,7 @@
   --gap-xl: 48px;
 
   /* header height */
-  --header-height: 52px;
+  --header-height: 56px;
 }
 
 *, ::before, ::after {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -87,7 +87,7 @@
   --gap-xl: 48px;
 
   /* header height */
-  --header-height: 56px;
+  --header-height: 52px;
 }
 
 *, ::before, ::after {


### PR DESCRIPTION
- Fixed the overlap by setting nav height w/ no t/b padding. 
![image](https://github.com/user-attachments/assets/13629a68-d4e5-4332-8d26-c842bbdf8c8d)

- Added max-width-90, max-width-90-desktop to marquee variant list
- Added function to make marquee title border same width as header
- Added bottom margin for columns .media row on mobile

Fix [#441](https://github.com/aemsites/creditacceptance/issues/441) 

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/car-buyers/how-it-works
- After: https://rparrish-header-overflow--creditacceptance--aemsites.aem.page/car-buyers/how-it-works

Testing criteria 
- size down to mobile and compare screens w/ before/after, confirm the top of the marquee graphic is showing and not covered by the nav. 
- Check the marquee title border goes same width as the heading, same on resize
- Look at the columns in mobile and confirm there is margin below the media (in mobile only)