### PR TITLE
Columns w/ icons - Text align above icons, consistent divider-blue-line

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -322,7 +322,6 @@
     }
 
     .divider-thin-blue-dot {
-        margin: 1rem 0 1rem 40px;
         width: auto;
     }
 }

--- a/blocks/text/text.css
+++ b/blocks/text/text.css
@@ -32,6 +32,21 @@
     padding: 0;
 }
 
+/* variants */
+.text-block.icon-margin .foreground {
+    margin-left: 2.5rem;
+
+    p { position: relative }
+
+    span.icon {
+        position: absolute;
+        left: -2.5rem;
+        top: 50%;
+        transform: translateY(-50%);
+        margin-inline-end: 0;
+    }
+}
+
 /* inner-spacing */
 .text-block.inner-spacing-1 .foreground { padding: 1rem; }
 .text-block.inner-spacing-2 .foreground { padding: 2rem; }


### PR DESCRIPTION
- Added variant to text block `text (icon-margin)` to support this style in a text block to group icon rows and preceding content. 
- removed the reduced margin on `columns .icon-elm .divider-thin-blue-dot` for consistency


<img width="1374" alt="Screenshot 2025-03-07 at 12 08 01 PM" src="https://github.com/user-attachments/assets/0f6e9b99-0392-438d-9956-4536040935f4" />


Fix [#428](https://github.com/aemsites/creditacceptance/issues/428) && [#427](https://github.com/aemsites/creditacceptance/issues/427)

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/rparrish/columns1
- After: https://rparrish-cols-icons--creditacceptance--aemsites.aem.page/drafts/rparrish/columns1


**Page urls in question**

Before
https://main--creditacceptance--aemsites.aem.page/about/contact-us
https://main--creditacceptance--aemsites.aem.page/car-buyers/how-it-works

After
https://rparrish-cols-icons--creditacceptance--aemsites.aem.page/about/contact-us
https://rparrish-cols-icons--creditacceptance--aemsites.aem.page/car-buyers/how-it-works

Testing criteria  - Take a look at the after page and see how I've re-authored this page w/ grid and `text (icon-margin)` blocks rather then columns. This will be easier to manage on the contact-us page for varying icon content groups. 

FYI, I will need to go into the contact us page after deploy to adjust the authoring. 
@kailasnadh790  - The default top/bottom margin for the `.divider-thin-blue-dot` seems kind of large when used inbetween paragraphs. Should we reduce that to just 1rem?

