### PR TITLE
Gap on columns.divided-list not respecting gap variant, added gap 5,6 to columns and section:gap

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -11,6 +11,8 @@
 .columns.gap-2 > div { gap: 0 2rem; }
 .columns.gap-3 > div { gap: 0 3rem; }
 .columns.gap-4 > div { gap: 0 4rem; }
+.columns.gap-5 > div { gap: 0 5rem; }
+.columns.gap-6 > div { gap: 0 6rem; }
 
 .columns img {
   width: 100%;
@@ -83,8 +85,6 @@
   gap: 0;
   counter-reset: ca-step-counter;
 }
-
-.columns.divided-list > div {  gap: 0 3rem; }
 
 .columns.stats > div > div {
   position: relative;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -583,6 +583,8 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
   &.gap-2 { gap: 2rem; }
   &.gap-3 { gap: 3rem; }
   &.gap-4 { gap: 4rem; }
+  &.gap-5 { gap: 5rem; }
+  &.gap-6 { gap: 6rem; }
 }
 
 .section.grid-section > .default-content-wrapper {


### PR DESCRIPTION
- removed gap on columns.divided-list to rely on variant or default
- added gap 5,6 …to columns and section:grid

<img width="1709" alt="Screenshot 2025-03-07 at 12 35 09 PM" src="https://github.com/user-attachments/assets/b91e7a05-c7dc-43ec-ac69-86ade19649f7" />


Fix [#451](https://github.com/aemsites/creditacceptance/issues/451)

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/campaign/prequalify
- After: https://rparrish-col-gap--creditacceptance--aemsites.aem.page/campaign/prequalify

Testing criteria - check the page has the authored gap variant `gap-4`