### PR TITLE
Marquee - max-width-90 added

### DIFF
--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -110,6 +110,11 @@ main > .section-outer > .section.marquee-container {
     width: 75%
 }
 
+.marquee.max-width-90 .foreground > div {
+    max-width: 90%;
+    width: 90%
+}
+
 .marquee.max-width-100 .foreground > div {
     max-width: 100%;
     width: 100%
@@ -138,12 +143,17 @@ main > .section-outer > .section.marquee-container {
         align-items: center;
     }
 
-    .marquee .foreground > div {
+    .marquee .foreground > div,
+    .marquee.max-width-50-desktop .foreground > div {
         max-width: 50%;
     }
-    
+
     .marquee.max-width-75-desktop .foreground > div {
         max-width: 75%;
+    }
+    
+    .marquee.max-width-90-desktop .foreground > div {
+        max-width: 90%;
     }
     
     .marquee.max-width-100-desktop .foreground > div {


### PR DESCRIPTION
Added `max-width-90, max-width-90-desktop` to marquee variant list

Fix [#441](https://github.com/aemsites/creditacceptance/issues/441#issuecomment-2707439850)

Test URLs:
Before: https://main--creditacceptance--aemsites.aem.page/car-buyers/how-it-works
After: https://rparrish-mq-max-width--creditacceptance--aemsites.aem.page/car-buyers/how-it-works

Testing criteria - max-width-90 etc was somehow omitted from past PR. Please verify it is added back in