### PR TITLE
Marquee `height-medium` && `height-large`

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -286,10 +286,16 @@ header .nav-brand {
   }
 }
 
-/* nav variant with logo */
-.header.logo-only .btn-mobile.btn-user,
-.header.logo-only .btn-mobile.btn-ham {
-  display: none;
+/* nav variant with logo only */
+.header.logo-only {
+    .nav-brand .default-content-wrapper p {
+        justify-content: start;
+    }
+
+    .btn-mobile.btn-user,
+    .btn-mobile.btn-ham {
+        display: none;
+    }
 }
 
 @media (width >= 960px) {
@@ -297,9 +303,9 @@ header .nav-brand {
   header nav {
     flex-direction: row;
     height: var(--header-height);
-    padding-top: 0.25rem;
-    padding-bottom: 0;
   }
+  
+  header .logo-only nav { flex-direction: column; }
 
   header .nav-brand {
     text-align: unset;

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -190,8 +190,7 @@ export default async function decorate(block) {
   const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/nav';
   const fragment = await loadFragment(navPath);
   decorateFragment(block, fragment);
-
-  if (block.querySelector('.nav-quick-links.nav-section')?.childNodes?.length === 0) {
+  if (!block.querySelector('.nav-quick-links.nav-section')) {
     block.classList.add('logo-only');
   }
 }

--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -11,6 +11,10 @@ main > .section-outer > .section.marquee-container {
 
 .marquee {
     position: relative;
+
+    --mq-height-s: 470px;
+    --mq-height-m: 550px;
+    --mq-height-l: 700px;   
 }
 
 .marquee, 
@@ -52,18 +56,14 @@ main > .section-outer > .section.marquee-container {
 .marquee .foreground {
     padding: 0;
     display: flex;
-    min-height: 470px;
+    min-height: var(--mq-height-s);
 }
 
 .marquee.vertical-center .foreground {  align-items: center; }
 
 .marquee.height-auto  .foreground {  min-height: unset; }
 
-.marquee.height-big .foreground { min-height: 700px; }
-
-.marquee .foreground > div {
-    padding: 2em 1em;
-}
+.marquee .foreground > div { padding: 2em 1em; }
 
 .marquee .heading { display: inline; }
 
@@ -162,7 +162,14 @@ main > .section-outer > .section.marquee-container {
         max-width: 100%;
     }
 
+
+    .marquee.height-medium .foreground { min-height: var(--mq-height-m); }
+
+    .marquee.height-large .foreground { min-height: var(--mq-height-l); }
+
     .marquee .action-area {
         gap: 1rem;
     }
+
+
 }

--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -59,6 +59,8 @@ main > .section-outer > .section.marquee-container {
 
 .marquee.height-auto  .foreground {  min-height: unset; }
 
+.marquee.height-big .foreground { min-height: 700px; }
+
 .marquee .foreground > div {
     padding: 2em 1em;
 }


### PR DESCRIPTION
- Added new variants to the marquee block `height-medium` && `height-large` which = `550px` && `700px` height for desktop up
- Addressed alignment issue on nav .logo-only so it's is justified left

Fix 
- marquee medium/large [#458](https://github.com/aemsites/creditacceptance/issues/458)
- logo-only alignment [#458](https://github.com/aemsites/creditacceptance/issues/458)

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/campaign/no-ssn-no-itin
- After: https://rparrish-mq-big2--creditacceptance--aemsites.aem.page/campaign/no-ssn-no-itin

Testing criteria - Look that the marquee height goes to 700 on desktop, Check the nav on logo-only pages that the brand logo is left aligned and account/hamburger icons are hidden on mobile. 