### PR TITLE
Header center desktopUp, `divider-thin-blue-dot`: margin reduce

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -288,10 +288,8 @@ header .nav-brand {
 
 /* nav variant with logo only */
 .header.logo-only {
-    nav { flex-direction: column; }
-
     .nav-brand .default-content-wrapper p {
-        justify-content: start;
+        justify-content: center;
     }
 
     .btn-mobile.btn-user,
@@ -306,6 +304,16 @@ header .nav-brand {
     flex-direction: row;
     height: var(--header-height);
   }
+  
+  .header.logo-only nav { 
+    flex-direction: column; 
+
+    .nav-brand .default-content-wrapper p {
+      justify-content: start;
+    }  
+  }
+
+  .header.logo-only 
 
   header .nav-brand {
     text-align: unset;
@@ -324,9 +332,6 @@ header .nav-brand {
   header .nav-main .default-content-wrapper {
     gap: 0;
   }
-
-  
-  .header.logo-only .nav-brand .default-content-wrapper p { justify-content: center; }
 
   /* nav brand */
   .nav-brand a {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -288,6 +288,8 @@ header .nav-brand {
 
 /* nav variant with logo only */
 .header.logo-only {
+    nav { flex-direction: column; }
+
     .nav-brand .default-content-wrapper p {
         justify-content: start;
     }
@@ -322,6 +324,9 @@ header .nav-brand {
   header .nav-main .default-content-wrapper {
     gap: 0;
   }
+
+  
+  .header.logo-only .nav-brand .default-content-wrapper p { justify-content: center; }
 
   /* nav brand */
   .nav-brand a {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -304,8 +304,6 @@ header .nav-brand {
     flex-direction: row;
     height: var(--header-height);
   }
-  
-  header .logo-only nav { flex-direction: column; }
 
   header .nav-brand {
     text-align: unset;

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -10,7 +10,7 @@ function isDarkColor(colors, colorStr) {
 
 function setTitleBorderWidth(heading, border) {
   const headerWidth = heading.getBoundingClientRect().width;
-  border.style.width = `${headerWidth}px`;
+  if (headerWidth > 0) border.style.width = `${headerWidth}px`;
 }
 
 function decorateIntro(el) {
@@ -42,10 +42,12 @@ function decorateIntro(el) {
       });
     }
   }
-  // Auto-toggle every 8 seconds
-  setTimeout(() => {
-    setTitleBorderWidth(heading, border);
-  }, '100');
+
+  document.addEventListener('fontsLoaded', () => {
+    setTimeout(() => {
+      setTitleBorderWidth(heading, border);
+    }, '200');
+  });
 
   window.addEventListener('resize', () => {
     setTitleBorderWidth(heading, border);

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -109,8 +109,8 @@ export default function decorate(block) {
   const foreground = children[children.length - 1];
   const background = children.length > 1 ? children[0] : null;
   if (background) {
-    decorateBlockBg(block, background, { useHandleFocalpoint: true });
     decoratePictures(background);
+    decorateBlockBg(block, background, { useHandleFocalpoint: true });
   }
   foreground.classList.add('foreground', 'container');
   decorateIntro(foreground);

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -13,7 +13,13 @@ function setTitleBorderWidth(heading, border) {
   if (headerWidth > 0) border.style.width = `${headerWidth}px`;
 }
 
-function decorateIntro(el) {
+async function asyncFontsLoaded(heading, border) {
+  document.addEventListener('fontsLoaded', () => {
+    setTitleBorderWidth(heading, border);
+  });
+}
+
+async function decorateIntro(el) {
   const heading = el.querySelector('h1, h2, h3, h4, h5, h6');
   if (!heading) return;
   const intro = heading.previousElementSibling;
@@ -43,11 +49,7 @@ function decorateIntro(el) {
     }
   }
 
-  document.addEventListener('fontsLoaded', () => {
-    setTimeout(() => {
-      setTitleBorderWidth(heading, border);
-    }, '200');
-  });
+  await asyncFontsLoaded(heading, border);
 
   window.addEventListener('resize', () => {
     setTitleBorderWidth(heading, border);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -27,6 +27,7 @@ async function loadFonts() {
   } catch (e) {
     // do nothing
   }
+  document.dispatchEvent(new CustomEvent('fontsLoaded'));
 }
 
 /**

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -613,6 +613,7 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
 
 .divider-thin-blue-dot {
   border: 1px dotted var(--credit-violet);
+  margin: 1rem 0;
 }
 
 header {


### PR DESCRIPTION
- addressed header center on desktop
- reduced margin on `divider-thin-blue-dot`
- wait for fontsLoaded before setting marquee intro border width

Fix 
- https://github.com/aemsites/creditacceptance/issues/458
- https://github.com/aemsites/creditacceptance/issues/462

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/about/contact-us
- After: https://rparrish-nav-line--creditacceptance--aemsites.aem.page/about/contact-us

- Before: https://main--creditacceptance--aemsites.aem.page/campaign/no-ssn-no-itin
- After: https://rparrish-nav-line--creditacceptance--aemsites.aem.page/campaign/no-ssn-no-itin

Testing criteria - verify changes on branch