### PR TITLE
Animated marquee - title border issue

### DIFF
--- a/blocks/marquee/animated/animated-toggle.css
+++ b/blocks/marquee/animated/animated-toggle.css
@@ -2,7 +2,7 @@
     background: white;
     overflow: hidden;
 
-    .view-1 { display: block; color: var(--ca-tangerine-400);}
+    .view-1 { display: inline; color: var(--ca-tangerine-400);}
     .view-2 { display: none; color: white; }
 
     p.intro {
@@ -25,7 +25,7 @@
 .animated-toggle.toggled {
     background: var(--ca-tangerine-400);
     .view-1 { display: none; }
-    .view-2 { display: block; }
+    .view-2 { display: inline; }
 
     p.intro {
         color: black;

--- a/blocks/marquee/animated/animated-toggle.css
+++ b/blocks/marquee/animated/animated-toggle.css
@@ -7,7 +7,7 @@
 
     p.intro {
         color: white;
-        span, div {
+        span, .border {
             background: var(--ca-tangerine-700);
         }
     }
@@ -29,7 +29,7 @@
 
     p.intro {
         color: black;
-        span, div { background: white; }
+        span, .border { background: white; }
     }
 }
 

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -71,7 +71,7 @@ function addCoins(el) {
 function initAnimatedMarquee(block) {
   const headings = block.querySelectorAll('h1, h2, h3, h4, h5, h6');
   headings.forEach((heading, i) => {
-    heading.classList.add(`view-${i + 1}`);
+    heading.classList.add(`view-${i + 1}`, 'heading');
   });
   const foreground = block.querySelector('.foreground');
   foreground.children[0].classList.add('toggle-copy');
@@ -84,7 +84,13 @@ function initAnimatedMarquee(block) {
   foreground.append(toggleAria);
   addCoins(foreground);
 
-  const toggleClass = () => { block.classList.toggle('toggled', input.checked); };
+  const toggleClass = () => {
+    block.classList.toggle('toggled', input.checked);
+    const heads = block.querySelectorAll('.heading');
+    const border = block.querySelector('.border');
+    const activeHeading = input.checked ? heads[1] : heads[0];
+    setTitleBorderWidth(activeHeading, border);
+  };
   input.addEventListener('change', toggleClass);
 
   // Auto-toggle every 8 seconds


### PR DESCRIPTION
CA noted the animated marquee border wasn't getting styled properly. The color on the border wasn't applied on switched state and the border width didn't follow the pattern where it goes the same width as the header. 

These issues are both addressed

Fix /na

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/dealers/purchase-program
- After: https://rparrish-mq-intro--creditacceptance--aemsites.aem.page/dealers/purchase-program

Testing criteria - Check that the border is styled on toggle w/ the correct color and is the width of the headline