### PR TITLE
Added tabs support for text-wrap

### DIFF
--- a/blocks/anchor-links/anchor-links.css
+++ b/blocks/anchor-links/anchor-links.css
@@ -1,5 +1,3 @@
-/* Text */
-
 .anchor-links {
     div > p {
         display: flex;

--- a/blocks/feed/feed.css
+++ b/blocks/feed/feed.css
@@ -4,7 +4,6 @@
 
 .feed-tabs-wrapper .feed-tabs {
     position: relative;
-
 }
 
 .feed-tabs-wrapper .feed-tabs-select-mobile {
@@ -41,22 +40,21 @@
 .feed-tabs-wrapper .feed-tabs-list-desktop li {
     list-style: none;
     margin: 0;
-    flex: 1 1 0;
 }
 
 
 .feed-tabs-wrapper .feed-tabs-list-desktop button {
     padding: 0.5rem 1.5rem;
     background: var(--secondary-brown);
-    border: none;
+    border: 1px solid var(--bs-border-color);
+    border-width: 1px 1px 0;
     min-height: 37px;
     width: 100%;
+    text-wrap: wrap;
 }
 
 .feed-tabs-wrapper .feed-tabs-list-desktop li.active button {
     background: var(--pure-white);
-    border-right: 1px solid var(--bs-border-color);
-    border-left: 1px solid var(--bs-border-color);
 }
 
 /* feed start */
@@ -117,8 +115,7 @@
     }
 
     .section-outer.feed-tabs .feed-tabs-wrapper {
-        padding: 0 12rem;
-        max-width: unset;
+        padding-bottom: 0;
     }
 
     .feed-tabs-wrapper .feed-tabs::after {

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -81,9 +81,10 @@ main > .section-outer > .section.tabs-container {
     font-family: var(--heading-font-family);
     font-weight: 600;
     margin-top: 0;
+    max-width: 202px;
     padding: 16px 8px 8px;
+    text-wrap: wrap;
     transition: color 0.1s ease-in-out;
-    max-width: 200px;
     z-index: 1;
 }
 


### PR DESCRIPTION
 - Addressed tabs list text-wrap - max-width and word wrap
 - Fixed issue on the-lot page where tabs border was only applied on active and caused content shift

Fix https://github.com/aemsites/creditacceptance/issues/473

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/dealers/portfolio-program/details-100
- After: https://rparrish-tabs-wrap--creditacceptance--aemsites.aem.page/dealers/portfolio-program/details-100

the-lot URL: 
- Before: https://main--creditacceptance--aemsites.aem.page/dealers/the-lot
- After: https://rparrish-tabs-wrap--creditacceptance--aemsites.aem.page/dealers/the-lot

Testing criteria - Confirm tabs list label text-wraps on smaller viewports. 