### PR TITLE
Headers `<strong>` fix

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -143,6 +143,10 @@ h1, h2, h3, h4, h5, h6 {
   line-height: 1.2;
   margin-bottom: 0.75rem;
   margin-top: 0;
+
+  b, strong {
+    font-family: var(--heading-font-family);
+  }
 }
 
 h1 {
@@ -175,6 +179,10 @@ h5 {
   font-size: var(--heading-font-size-s);
   font-weight: 400;
   margin-bottom: 12px;
+
+  b, strong {
+    font-family: var(--ff-acceptance-demi-bold);
+  }
 }
 
 h6 {


### PR DESCRIPTION
- set header `<strong>` w/ correct font-family

Fix https://github.com/aemsites/creditacceptance/issues/466 feedback post merge

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/careers
- After: https://rparrish-htags--creditacceptance--aemsites.aem.page/careers

Testing criteria - test that any header w/ a strong tag still maintains the correct font-family `Acceptance Bold`