### PR TITLE
Added grid row-gap-0 style

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -600,6 +600,7 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
   &.gap-4 { gap: 4rem; }
   &.gap-5 { gap: 5rem; }
   &.gap-6 { gap: 6rem; }
+  &.row-gap-0 { row-gap: 0;}
 }
 
 .section.grid-section > .default-content-wrapper {


### PR DESCRIPTION
- Added `row-gap-0` to section grid styles

FYI - I only added row-gap-0 for now... If more options are needed in the future we can add them then. Ex. `row-gap-3` OR `col-gap-3` etc. 

Fix https://github.com/aemsites/creditacceptance/issues/488

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/about/contact-us
- After: https://rparrish-row-gap--creditacceptance--aemsites.aem.page/about/contact-us

Testing criteria - check the page on mobile and confirm the `row-gap` is 0 on the grid content in the 'Location & Holiday closures` section

<img width="792" alt="Screenshot 2025-03-13 at 2 08 30 PM" src="https://github.com/user-attachments/assets/fb1624af-3d19-4257-94fb-0ee437fcfc85" />
