### PR TITLE
Added grid gap variants `gap-m` & `gap-l` and Fixed big-icon headlines to support h3 tags

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -350,7 +350,7 @@
   
     .columns .media { margin-bottom: 1.5rem; }
   
-    .columns.big-icons .copy:first-of-type > :is(p:not(.icon-elm), , h3, h4),
+    .columns.big-icons .copy:first-of-type > :is(p:not(.icon-elm), h3, h4),
     .columns.big-icons .copy:has(.icon-elm) + .copy > :is(p:not(.icon-elm), h3, h4) {
         margin-inline-start: 80px;
     }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -350,8 +350,8 @@
   
     .columns .media { margin-bottom: 1.5rem; }
   
-    .columns.big-icons .copy:first-of-type > :is(p:not(.icon-elm), h4),
-    .columns.big-icons .copy:has(.icon-elm) + .copy > :is(p:not(.icon-elm), h4) {
+    .columns.big-icons .copy:first-of-type > :is(p:not(.icon-elm), , h3, h4),
+    .columns.big-icons .copy:has(.icon-elm) + .copy > :is(p:not(.icon-elm), h3, h4) {
         margin-inline-start: 80px;
     }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -595,8 +595,10 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
   }
   
   &.gap-0 { gap: 0; }
-  &.gap-2 { gap: 2rem; }
-  &.gap-3 { gap: 3rem; }
+  &.gap-2,
+  &.gap-m { gap: 2rem; }
+  &.gap-3,
+  &.gap-l { gap: 3rem; }
   &.gap-4 { gap: 4rem; }
   &.gap-5 { gap: 5rem; }
   &.gap-6 { gap: 6rem; }
@@ -745,12 +747,18 @@ header {
         &.grid-template-columns-10-auto { grid-template-columns: repeat(10, auto); }
         &.grid-template-columns-11-auto { grid-template-columns: repeat(11, auto); }
         &.grid-template-columns-12-auto { grid-template-columns: repeat(12, auto); }
+
+
     }
     
 }
 
 @media screen and (width >= 1200px) {
     :root { --container-width: 1140px; }
+    .grid-section {
+        &.gap-m { gap: 5rem; }
+        &.gap-l { gap: 6rem; }
+    }   
 }
 
 @media screen and (width >= 1400px) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -595,10 +595,8 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
   }
   
   &.gap-0 { gap: 0; }
-  &.gap-2,
-  &.gap-m { gap: 2rem; }
-  &.gap-3,
-  &.gap-l { gap: 3rem; }
+  &.gap-2, &.gap-m { gap: 2rem; }
+  &.gap-3, &.gap-l { gap: 3rem; }
   &.gap-4 { gap: 4rem; }
   &.gap-5 { gap: 5rem; }
   &.gap-6 { gap: 6rem; }
@@ -747,8 +745,6 @@ header {
         &.grid-template-columns-10-auto { grid-template-columns: repeat(10, auto); }
         &.grid-template-columns-11-auto { grid-template-columns: repeat(11, auto); }
         &.grid-template-columns-12-auto { grid-template-columns: repeat(12, auto); }
-
-
     }
     
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -751,6 +751,7 @@ header {
 
 @media screen and (width >= 1200px) {
     :root { --container-width: 1140px; }
+    
     .grid-section {
         &.gap-m { gap: 5rem; }
         &.gap-l { gap: 6rem; }


### PR DESCRIPTION
- Added new grid gap variants that are scalable in different viewports. #496 
`gap-m` = `2rem / 5rem` (mobile, tablet / big desktop [>1200])
`gap-l` = `3rem / 6rem` (mobile, tablet / big desktop [>1200])

- Included support for big-icons h3 headers to have inline margin. (same as h4) #497

Fix https://github.com/aemsites/creditacceptance/issues/496 && https://github.com/aemsites/creditacceptance/issues/497

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/dealers/join-our-network
- After: https://rparrish-grid-gaps--creditacceptance--aemsites.aem.page/dealers/join-our-network

Testing criteria 
- Check in tablet viewport that the content doesn't go outside the grid column area
<img width="870" alt="Screenshot 2025-03-19 at 12 49 07 PM" src="https://github.com/user-attachments/assets/254a7e2f-8d69-4c87-9982-3884d48462a4" />

- Check in mobile viewport that the first big-icon headline is properly indented and doesn't overlap w/ the icon element
<img width="381" alt="Screenshot 2025-03-19 at 12 49 15 PM" src="https://github.com/user-attachments/assets/f1047b44-fb00-49c0-8ca7-e86ac6b6d3c0" />
