### PR TITLE
#514 - fix min grid item width

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -154,11 +154,11 @@
     }
 
     .cards.three-up > ul {
-        grid-template-columns: repeat(3, minmax(257px, 1fr));
+        grid-template-columns: repeat(3, minmax(230px, 1fr));
     }
 
     .cards.four-up > ul {
-        grid-template-columns: repeat(4, minmax(257px, 1fr));
+        grid-template-columns: repeat(4, minmax(200px, 1fr));
     }
 }
 


### PR DESCRIPTION
Fix #514 

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/car-buyers/express-lane/financial-education
- After: https://smalla-514--creditacceptance--aemsites.aem.page/car-buyers/express-lane/financial-education

Testing criteria - Cards shouldn't overflow the screen width in any viewport.