### PR TITLE
Nav-customers submenu out of order

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -203,6 +203,11 @@ header .nav-brand {
       width: 100%;
       padding: 0.5rem 0;
     }
+
+    .column-1 {  
+        border-bottom: 1px dotted var(--menu-accent-gray); 
+        margin-bottom: 1rem;
+    }
   }
 
   details summary:hover {
@@ -384,6 +389,11 @@ header .nav-brand {
       grid-gap: 0 1rem;
     }
     
+    .column-1 {  
+        border-bottom: none; 
+        margin-bottom: 0;
+    }
+
     summary:hover,
     details[open] summary {
       background: var(--menu-bg-hover);

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -381,6 +381,11 @@ header .nav-brand {
             background: var(--menu-bg-hover);
           }
         }
+        
+        .column-1 {  
+          border-bottom: none; 
+          margin-bottom: 0;
+        }
     }
 
     .detail-0 ul {
@@ -389,11 +394,6 @@ header .nav-brand {
       grid-gap: 0 1rem;
     }
     
-    .column-1 {  
-        border-bottom: none !important; 
-        margin-bottom: 0 !important;
-    }
-
     summary:hover,
     details[open] summary {
       background: var(--menu-bg-hover);

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -390,8 +390,8 @@ header .nav-brand {
     }
     
     .column-1 {  
-        border-bottom: none; 
-        margin-bottom: 0;
+        border-bottom: none !important; 
+        margin-bottom: 0 !important;
     }
 
     summary:hover,

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -53,6 +53,24 @@ function createRipple(event) {
   button.prepend(circle);
 }
 
+function groupListColumns(list) {
+  const items = Array.from(list.children);
+  const columns = [
+    createTag('div', { class: 'column-1' }),
+    createTag('div', { class: 'column-2' }),
+  ];
+  list.append(...columns);
+  let currentColumnIndex = 0;
+  items.forEach((item) => {
+    if (item.textContent.trim() === '---') {
+      currentColumnIndex += 1;
+      item.remove();
+    } else {
+      columns[currentColumnIndex].appendChild(item); // Append to the current column
+    }
+  });
+}
+
 function decorateMainMenu(section) {
   const navHeaders = section?.querySelectorAll('h3');
   if (!navHeaders) return;
@@ -64,6 +82,7 @@ function decorateMainMenu(section) {
     if (!list) return;
     const listLinks = list.querySelectorAll('li');
     details.append(list);
+    groupListColumns(list);
     /* toggle on mouseover on mouse-based/desktop OR hybrid devices/desktop */
     if ((deviceType === 'mouse-based' && isDesktopMQ.matches)
       || (deviceType === 'hybrid' && isDesktopMQ.matches)


### PR DESCRIPTION
Added a method to the nav-customers to denote a column division. This works by adding a list w/ `---` acting as a divider for menu items. 

<img width="400" alt="Screenshot 2025-03-21 at 10 18 37 AM" src="https://github.com/user-attachments/assets/f8420f04-acb1-4974-b76f-d0ed72958c91" />

<img width="1880" alt="Screenshot 2025-03-21 at 10 19 06 AM" src="https://github.com/user-attachments/assets/0e7fc195-256a-4d31-9041-3ad07dc7c21f" />

Fix https://github.com/aemsites/creditacceptance/issues/510

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/rparrish/
- After: https://rparrish-nav-order--creditacceptance--aemsites.aem.page/drafts/rparrish/

Testing criteria - Check that the menu item columns get authored by the method above. 
Note: this will require a small authoring adjustment to the nav menu items. 

