### PR TITLE
#520 - fix reviewer's detail alignment

### DIFF
--- a/blocks/testimonials/testimonials.css
+++ b/blocks/testimonials/testimonials.css
@@ -24,6 +24,7 @@
 
 .testimonials .card-description {
     display: -webkit-box;
+    min-height: 100px;
     max-height: 130px;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
This gap issue was rather because of the position of the reviewer's details.

Fix #520 

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/customers/reviews
- After: https://smalla-520--creditacceptance--aemsites.aem.page/customers/reviews