### PR TITLE
Columns .bg-shape-right update and Accordion title w/ paragraphs in .arrow type

### DIFF
--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -40,6 +40,7 @@
 }
 
 .accordion.arrow details summary {
+    display: block;
     padding-right: 46px;
     color: #0d5d73;
 }
@@ -99,10 +100,6 @@
 
 .accordion.arrow details[open] summary::after {
     transform: translateY(-50%) rotate(135deg);
-}
-
-.accordion.arrow details summary {
-    display: block;
 }
 
 .accordion.arrow details summary span.icon {

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -101,9 +101,17 @@
     transform: translateY(-50%) rotate(135deg);
 }
 
+.accordion.arrow details summary {
+    display: block;
+}
 
 .accordion.arrow details summary span.icon {
     vertical-align: baseline;
+}
+
+.accordion.arrow details summary p > span.icon {
+    vertical-align: top;
+    height: 1.25rem;
 }
 
 .accordion details .accordion-item-body {

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -265,15 +265,14 @@
 
 .columns.bg-shape-right > div > :nth-child(2){
     position: relative;
-    overflow: hidden;
     z-index: 0;
 
-    ol { margin: 3rem 1rem 2rem 8rem; }
+    ol { margin: 2rem 1rem 2rem 5rem; }
     
     &::after {
         position: absolute;
         background: white;
-        border-radius: 192px 0 0 32px;
+        border-radius: 122px 0 0 32px;
         content: '';
         width: 100vw;
         height: 100%;


### PR DESCRIPTION
Columns `.bg-shape-right` has overflow, reduced radius & padding
accordion.arrow heading with paragraph and icon

Fix https://github.com/aemsites/creditacceptance/issues/540

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/jpetersen/regression/accordions
- After: https://rparrish-accord--creditacceptance--aemsites.aem.page/drafts/jpetersen/regression/accordions

HP
- Before: https://main--creditacceptance--aemsites.aem.page/
- After: https://rparrish-accord--creditacceptance--aemsites.aem.page/

Testing criteria - what should the reviewer look for in your PR:

test this branch on other known uses of accordion blocks to check for regression