### PR TITLE
[#546] Resource Cards icon alignment

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -90,7 +90,7 @@
 }
 
 .cards .cards-card-icon {
-    margin-block: 1rem 0;
+    margin: 16px 16px 0;
 }
 
 .cards .cards-card-icon .icon-masked {


### PR DESCRIPTION
Fix #546 
Note, the part of this ticket mentions incorrect CTA copy/links, this is a content issue 

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/car-buyers/resources
- After: https://nrego-card-icon-alignment--creditacceptance--aemsites.aem.page/car-buyers/resources

Testing criteria - icon should be left aligned with the copy 