### PR TITLE
[#545] Modal close button overlapped by content

### DIFF
--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -24,8 +24,7 @@ body.modal-open {
   overscroll-behavior: none;
   width: 100%;
   max-height: calc(100dvh - (2 * var(--header-height)) - 48px);
-  padding: 24px;
-  padding-top: 0;
+  padding: 40px 16px;
 }
 
 @media (width >= 900px) {
@@ -35,14 +34,13 @@ body.modal-open {
   
   .modal dialog .modal-content {
     max-height: calc(100dvh - (2 * var(--header-height)) - 64px);
-    padding-top: 0;
   }
 }
 
 .modal .close-button {
   position: absolute;
-  top: 0;
-  right: 0;
+  top: 4px;
+  right: 4px;
   width: 44px;
   height: 44px;
   margin: 0;


### PR DESCRIPTION
Fix for modal close button being overlapped by the video content 

Fix #545 

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/car-buyers/resources
- After: https://nrego-modal-close--creditacceptance--aemsites.aem.page/car-buyers/resources

Testing criteria - a user should be able to clearly see and use the close button on the modal 