### PR TITLE
Accordion summary paragraph color, column row-gap styles

### DIFF
--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -43,6 +43,8 @@
     display: block;
     padding-right: 46px;
     color: #0d5d73;
+    
+    p { color: var(--text-color); }
 }
 
 .accordion details summary .accordion-item-plus,

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -13,6 +13,10 @@
 .columns.gap-4 > div { gap: 0 4rem; }
 .columns.gap-5 > div { gap: 0 5rem; }
 .columns.gap-6 > div { gap: 0 6rem; }
+.columns.row-gap-1 > div { row-gap: 1rem; }
+.columns.row-gap-2 > div { row-gap: 2rem; }
+.columns.row-gap-3 > div { row-gap: 3rem; }
+.columns.row-gap-4 > div { row-gap: 4rem; }
 
 .columns img {
   width: 100%;


### PR DESCRIPTION
- made accordion summary paragraphs normal text color
- added row-gap 1-4 on columns

Fix: https://github.com/aemsites/creditacceptance/issues/540

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/jpetersen/regression/accordions
- After: https://rparrish-accord-fix--creditacceptance--aemsites.aem.page/drafts/jpetersen/regression/accordions

Testing criteria - check you can author `row-gap-2` etc. Make sure accordion summary `<p>` tags are `text-color`