### PR TITLE
[#535] Divider dots too long

### DIFF
--- a/blocks/anchor-links/anchor-links.css
+++ b/blocks/anchor-links/anchor-links.css
@@ -23,7 +23,7 @@
         &::after {
             content: '';
             position: absolute;
-            border: 1px dotted var(--ca-aqua);
+            border-right: 1px dotted var(--ca-aqua);
             height: 100%;
             right: -16px;
             top: 0;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -628,7 +628,8 @@ main > .section-outer:has(.section.strong-bottom-shadow) {
 }
 
 .divider-thin-blue-dot {
-  border: 1px dotted var(--credit-violet);
+  border: none;
+  border-bottom: 1px dotted var(--credit-violet);
   margin: 1rem 0;
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #535 

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/about/contact-us
- After: https://nrego-dot-dividers--creditacceptance--aemsites.aem.page/about/contact-us

Testing criteria - dots should be smaller in size.

Additional testing urls: 
- Before: https://main--creditacceptance--aemsites.aem.page/dealers/resources
- After: https://nrego-dot-dividers--creditacceptance--aemsites.aem.page/dealers/resources

