### PR TITLE
Columns `media-unbound` image clipping issue fixed and added a `media-contain` variant

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -398,11 +398,10 @@
 
   .columns.media-unbound .media-count-1 {
     position: relative;
-
+    
     picture {
       position: absolute;
-      width: 50vw;
-      height: 100%;
+      width: calc(50vw - ((100vw - var(--container-width)) / 6));
       overflow: visible;
     }
 

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -406,7 +406,6 @@
 
     picture {
       position: absolute;
-      width: 50vw;
       width: var(--unbound-width);
       height: 100%;
       overflow: visible;
@@ -428,6 +427,15 @@
   .columns.media-unbound .media-left img {
     object-position: bottom right;
     border-radius: 0 8px;
+  }
+
+  .columns.media-unbound.media-contain img {
+    object-fit: contain;
+    object-position: top left;
+  }
+
+  .columns.media-unbound.media-contain .media-left img {
+    object-position: top right;
   }
 
   .columns.stats > div {

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -398,16 +398,17 @@
 
   .columns.media-unbound .media-count-1 {
     position: relative;
-    
+
     picture {
       position: absolute;
-      width: calc(50vw - ((100vw - var(--container-width)) / 6));
+      width: calc(100% + ((100vw - var(--container-width)) / 2));
+      height: 100%;
       overflow: visible;
     }
 
     img {
-      object-fit: cover;
-      object-position: bottom left;
+      object-fit: contain;
+      object-position: top left;
       width: 100%;
       height: 100%;
       border-radius: 8px 0 0;
@@ -419,7 +420,7 @@
   }
 
   .columns.media-unbound .media-left img {
-    object-position: bottom right;
+    object-position: top right;
     border-radius: 0 8px;
   }
 
@@ -457,4 +458,11 @@
   .columns.calculation .separator {
     display: none;
   }
+}
+
+@media  screen and (width >= 1440px) {
+    .columns.media-unbound .media-count-1 img {
+        object-fit: cover;
+    }
+    
 }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -3,6 +3,8 @@
   display: flex;
   flex-direction: column;
   gap: 0 1.5rem;
+
+  --unbound-width: calc(100% + ((100vw - var(--container-width)) / 2));
 }
 
 .columns.columns-2-cols > div { gap: 0 3rem; }
@@ -404,14 +406,15 @@
 
     picture {
       position: absolute;
-      width: calc(100% + ((100vw - var(--container-width)) / 2));
+      width: 50vw;
+      width: var(--unbound-width);
       height: 100%;
       overflow: visible;
     }
 
     img {
-      object-fit: contain;
-      object-position: top left;
+      object-fit: cover;
+      object-position: bottom left;
       width: 100%;
       height: 100%;
       border-radius: 8px 0 0;
@@ -423,7 +426,7 @@
   }
 
   .columns.media-unbound .media-left img {
-    object-position: top right;
+    object-position: bottom right;
     border-radius: 0 8px;
   }
 
@@ -461,11 +464,4 @@
   .columns.calculation .separator {
     display: none;
   }
-}
-
-@media  screen and (width >= 1440px) {
-    .columns.media-unbound .media-count-1 img {
-        object-fit: cover;
-    }
-    
 }


### PR DESCRIPTION
In the [columns] block there is a variant `media-unbound` which allows the image to go outside the page margins to meet up w/ the window edge. This image calculation does a simple 50vw which puts it outside the viewport and some image cropping is happening. 

- adjusted this `<picture>` width calculation to be `100% relative column width + page gutter space` to accurately measure the width.
- added another optional variant `media-contain` which sets this image to be `object-fit: contain` rather than the default `cover`

Fix https://github.com/aemsites/creditacceptance/issues/515

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/
- After: https://rparrish-col-img--creditacceptance--aemsites.aem.page/
https://rparrish-col-img--creditacceptance--aemsites.aem.page/car-buyers/how-it-works
https://rparrish-col-img--creditacceptance--aemsites.aem.page/customers
https://rparrish-col-img--creditacceptance--aemsites.aem.page/about/esg
https://rparrish-col-img--creditacceptance--aemsites.aem.page/drafts/rparrish/columns

Testing criteria - Take a look at the above URLS and confirm the images are display to the edge and aren't cropped out of the window. - On my draft, confirm the new variant `media-contain` does as advertised. 