### PR TITLE
Columns `media-unbound, media-contain` display issues

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -433,13 +433,17 @@
     border-radius: 0 8px;
   }
 
-  .columns.media-unbound.media-contain img {
-    object-fit: contain;
-    object-position: top left;
-  }
-
-  .columns.media-unbound.media-contain .media-left img {
-    object-position: top right;
+  .columns.media-unbound.media-contain {
+    img {
+        object-fit: contain;
+        object-position: top left;
+    }
+    .media-left img {
+        object-position: top right;
+    }
+    .media-count-1  picture {
+        height: auto;
+    }
   }
 
   .columns.stats > div {

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -439,9 +439,11 @@
         object-fit: contain;
         object-position: top left;
     }
+
     .media-left img {
         object-position: top right;
     }
+    
     .media-count-1  picture {
         height: auto;
     }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -32,7 +32,8 @@
   order: 0;
 }
 
-.columns.vertical-center .copy {
+.columns.vertical-center .copy,
+.columns.vertical-center .media-copy {
   align-content: center;
 }
 

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -16,27 +16,52 @@ function decorateFlexRows(block) {
   });
 }
 
-function getMediaHeightValue(e) {
-  const match = [...e.classList].find((cls) => cls.startsWith('media-height-'))?.match(/^media-height-(\d+)$/);
-  return match ? parseInt(match[1], 10) : null;
+function getMediaHeightValue(el, fromAttribute = false) {
+  if (fromAttribute) {
+    const match = [...el.classList].find((cls) => cls.startsWith('media-height-'))?.match(/^media-height-(\d+)$/);
+    return match ? parseInt(match[1], 10) : null;
+  }
+  const media = el.querySelector('.media-count-1 img');
+  return media?.height || null;
 }
 
-function applyMediaHeight(block) {
-  const heightValue = getMediaHeightValue(block);
-  if (!heightValue) return;
+function applyMediaHeight(block, fromAttribute = false) {
+  const heightValue = getMediaHeightValue(block, fromAttribute);
   const media = block.querySelector('.media');
-  const isDesktop = window.matchMedia('(min-width: 960px)');
-  if (isDesktop.matches) {
+  const isDesktop = window.matchMedia('(min-width: 960px)').matches;
+  if (heightValue && isDesktop) {
     media.style.setProperty('height', `${heightValue}px`);
   } else {
     media.style.removeProperty('height');
   }
 }
 
+function applyMediaHeightAfterScaling(block) {
+  const media = block.querySelector('.media-count-1 img');
+  const mediaContainer = block.querySelector('.media');
+
+  if (!media || !mediaContainer) return;
+
+  const observer = new ResizeObserver(() => {
+    observer.disconnect();
+    applyMediaHeight(block, false);
+  });
+
+  if (media.complete) {
+    observer.observe(mediaContainer);
+  } else {
+    media.onload = () => {
+      observer.observe(mediaContainer);
+    };
+  }
+}
+
 // Call applyMediaHeight for all elements with the media-unbound class on initial load
 window.addEventListener('resize', () => {
-  const mediaUnboundBlocks = document.querySelectorAll('.media-unbound');
-  mediaUnboundBlocks.forEach((block) => { applyMediaHeight(block); });
+  const mediaUnbound = document.querySelectorAll('.media-unbound');
+  const mediaUnboundContain = document.querySelectorAll('.media-unbound.media-contain');
+  mediaUnbound?.forEach((block) => { applyMediaHeight(block, true); });
+  mediaUnboundContain?.forEach((block) => { applyMediaHeight(block, false); });
 });
 
 // Check for columns with CTA icons
@@ -116,7 +141,7 @@ export default function decorate(block) {
   });
   // flex basis
   decorateFlexRows(block);
-  if (block.classList.contains('media-unbound')) applyMediaHeight(block);
   if (block.classList.contains('calculation')) decorateColumnsCalculation(block);
   if ([...block.classList].some((cls) => cls.startsWith('stats-'))) applyStatsClasses(block);
+  if (block.classList.contains('media-unbound')) applyMediaHeightAfterScaling(block);
 }

--- a/blocks/jon-representative/jon-representative.js
+++ b/blocks/jon-representative/jon-representative.js
@@ -34,6 +34,7 @@ export default async function initialize(block) {
         `;
       }
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.error('Error parsing jon-representative data from localStorage:', error);
     }
     const columnsEl = block.querySelector('.columns');


### PR DESCRIPTION
Adds support to the [columns] block for combo variants `media-unbound, media-contain` 
This will display media w out the image getting clipped and scales the column height to the relative media height on `<960` viewports.  

Fix [#515](https://github.com/aemsites/creditacceptance/issues/515)

Test URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/drafts/jpetersen/regression/columns
- After: https://rparrish-col-img-scale--creditacceptance--aemsites.aem.page/drafts/jpetersen/regression/columns

HOME URLs:
- Before: https://main--creditacceptance--aemsites.aem.page/
- After: https://rparrish-col-img-scale--creditacceptance--aemsites.aem.page/

Testing criteria - Confirm these variants work as expected and no regression or display issues are seen across any usage